### PR TITLE
Remove unnecessary import from Instruction.java

### DIFF
--- a/src/org/edumips64/core/is/Instruction.java
+++ b/src/org/edumips64/core/is/Instruction.java
@@ -29,7 +29,6 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.lang.Enum.*;
 //debug
-import org.edumips64.Main;
 /**Abstract class: it provides all methods and attributes for each instruction type
  *
  * @author Trubia Massimo, Russo Daniele


### PR DESCRIPTION
Unnecessary import of org.edumips64.Main removed
