### PR TITLE
Factor out argv parsing

### DIFF
--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -31,6 +31,7 @@ import org.edumips64.core.parser.ParserMultiWarningException;
 import org.edumips64.ui.swing.img.*;
 import org.edumips64.ui.swing.*;
 import org.edumips64.utils.*;
+import org.edumips64.utils.ApplicationSettings;
 import org.edumips64.utils.io.*;
 
 import java.awt.*;
@@ -42,7 +43,6 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.logging.Handler;
 import java.io.File;
 import java.io.IOException;
 
@@ -99,95 +99,24 @@ public class Main extends JApplet {
   private static List<JInternalFrame> ordered_frames;
 
   private static String openedFile = null;
-  private static boolean debug_mode = false;
   private static JDesktopPane desk;
 
   /** Callbacks for CPUSwingWorker */
   private static Runnable initCallback, haltCallback, finalizeCallback;
 
-  private static void usage() {
-    showVersion();
-    System.out.println(CurrentLocale.getString("HT.Options"));
-    System.out.println(CurrentLocale.getString("HT.File"));
-    System.out.println(CurrentLocale.getString("HT.Debug"));
-    System.out.println(CurrentLocale.getString("HT.Help"));
-    System.out.println(CurrentLocale.getString("HT.Reset"));
-    System.out.println(CurrentLocale.getString("HT.Version"));
-  }
-
-  private static void showVersion() {
-    System.out.println("EduMIPS64 version " + VERSION + " (codename: " + CODENAME + ", git revision " + GIT_REVISION + ", built on " + BUILD_DATE + ") - Ciao 'mbare.");
-  }
-
-  // Parses the command-line arguments.
-  // Returns the filename to open (if any) and sets parameters such as logging. If necessary, exits.
-  public static String parseArgsOrExit(String[] args) {
-    // Checking CLI parameters.
-    String toOpen = null;
-    boolean printUsageAndExit = false;
-    boolean printVersionAndExit = false;
-
-    if (args.length > 0) {
-      for (int i = 0; i < args.length; ++i) {
-        if (args[i].compareTo("-f") == 0 || args[i].compareTo("--file") == 0) {
-          if (toOpen == null && ++i == args.length) {
-            System.err.println(CurrentLocale.getString("HT.MissingFile") + "\n");
-            printUsageAndExit = true;
-          } else if (toOpen != null) {
-            System.err.println(CurrentLocale.getString("HT.MultipleFile") + "\n");
-            printUsageAndExit = true;
-          } else {
-            toOpen = args[i];
-          }
-        } else if (args[i].compareTo("-d") == 0 || args[i].compareTo("--debug") == 0) {
-          debug_mode = true;
-        } else if (args[i].compareTo("-h") == 0 || args[i].compareTo("--help") == 0) {
-          printUsageAndExit = true;
-        } else if (args[i].compareTo("-v") == 0 || args[i].compareTo("--version") == 0) {
-          printVersionAndExit = true;
-        } else if (args[i].compareTo("-r") == 0 || args[i].compareTo("--reset") == 0) {
-          configStore.resetConfiguration();
-        } else {
-          System.err.println(CurrentLocale.getString("HT.UnrecognizedArgs") + ": " + args[i] + "\n");
-          printUsageAndExit = true;
-        }
-
-        if (printUsageAndExit) {
-          usage();
-          System.exit(0);
-        }
-
-        if (printVersionAndExit) {
-          showVersion();
-          System.exit(0);
-        }
-      }
-    }
-
-    if (!debug_mode) {
-      // Disable logging message whose level is less than WARNING.
-      Logger rootLogger = log.getParent();
-
-      for (Handler h : rootLogger.getHandlers()) {
-        h.setLevel(Level.WARNING);
-      }
-    }
-    return toOpen;
-  }
-
   public static void main(String args[]) {
     // Meta properties.
-    VERSION = MetaInfo.get("Signature-Version");
-    CODENAME = MetaInfo.get("Codename");
-    BUILD_DATE = MetaInfo.get("Build-Date");
-    GIT_REVISION = MetaInfo.get("Git-Revision");
+    VERSION = ApplicationSettings.VERSION;
+    CODENAME = ApplicationSettings.CODENAME;
+    BUILD_DATE = ApplicationSettings.BUILD_DATE;
+    GIT_REVISION = ApplicationSettings.GIT_REVISION;
 
-    String toOpen = parseArgsOrExit(args);
+    String toOpen = ApplicationSettings.parseArgsOrExit(args);
 
     // Configure logger format.
     System.setProperty("java.util.logging.SimpleFormatter.format", "%1$tm%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n");
 
-    showVersion();
+    ApplicationSettings.showVersion();
 
     // Creating the main JFrame
     JFrame.setDefaultLookAndFeelDecorated(true);
@@ -281,7 +210,7 @@ public class Main extends JApplet {
     JDialog.setDefaultLookAndFeelDecorated(true);
     LocalFileUtils lfu = new LocalFileUtils();
 
-    configStore = new JavaPrefsConfigStore(ConfigStore.defaults);
+    configStore = ApplicationSettings.configStore;
     CurrentLocale.setConfig(configStore);
     jfc = new JFileChooser(new File(configStore.getString(ConfigKey.LAST_DIR)));
     setFileChooserFont(jfc.getComponents());

--- a/src/main/java/org/edumips64/MainCLI.java
+++ b/src/main/java/org/edumips64/MainCLI.java
@@ -43,8 +43,7 @@ public class MainCLI {
       CurrentLocale.setConfig(cfg);
 
       // Parse the args as early as possible, since it will influence logging level as well.
-      // TODO: extract parseArgsOrExit out of the Main class.
-      String toOpen = Main.parseArgsOrExit(args);
+      String toOpen = ApplicationSettings.parseArgsOrExit(args);
 
       // Initialize the CPU and all its dependencies.
       Memory memory = new Memory();

--- a/src/main/java/org/edumips64/utils/ApplicationSettings.java
+++ b/src/main/java/org/edumips64/utils/ApplicationSettings.java
@@ -1,0 +1,94 @@
+package org.edumips64.utils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.Handler;
+
+public class ApplicationSettings {
+  public final static String VERSION;
+  public final static String CODENAME;
+  public final static String BUILD_DATE;
+  public final static String GIT_REVISION;
+
+  public static ConfigStore configStore;
+  private static boolean debug_mode = false;
+
+  static {
+    VERSION = MetaInfo.get("Signature-Version");
+    CODENAME = MetaInfo.get("Codename");
+    BUILD_DATE = MetaInfo.get("Build-Date");
+    GIT_REVISION = MetaInfo.get("Git-Revision");
+    configStore = new JavaPrefsConfigStore(ConfigStore.defaults);
+  }
+
+  // Parses the command-line arguments.
+  // Returns the filename to open (if any) and sets parameters such as logging. If necessary, exits.
+  public static String parseArgsOrExit(String[] args) {
+    // Checking CLI parameters.
+    String toOpen = null;
+    boolean printUsageAndExit = false;
+    boolean printVersionAndExit = false;
+
+    if (args.length > 0) {
+      for (int i = 0; i < args.length; ++i) {
+        if (args[i].compareTo("-f") == 0 || args[i].compareTo("--file") == 0) {
+          if (toOpen == null && ++i == args.length) {
+            System.err.println(CurrentLocale.getString("HT.MissingFile") + "\n");
+            printUsageAndExit = true;
+          } else if (toOpen != null) {
+            System.err.println(CurrentLocale.getString("HT.MultipleFile") + "\n");
+            printUsageAndExit = true;
+          } else {
+            toOpen = args[i];
+          }
+        } else if (args[i].compareTo("-d") == 0 || args[i].compareTo("--debug") == 0) {
+          debug_mode = true;
+        } else if (args[i].compareTo("-h") == 0 || args[i].compareTo("--help") == 0) {
+          printUsageAndExit = true;
+        } else if (args[i].compareTo("-v") == 0 || args[i].compareTo("--version") == 0) {
+          printVersionAndExit = true;
+        } else if (args[i].compareTo("-r") == 0 || args[i].compareTo("--reset") == 0) {
+          configStore.resetConfiguration();
+        } else {
+          System.err.println(CurrentLocale.getString("HT.UnrecognizedArgs") + ": " + args[i] + "\n");
+          printUsageAndExit = true;
+        }
+
+        if (printUsageAndExit) {
+          usage();
+          System.exit(0);
+        }
+
+        if (printVersionAndExit) {
+          showVersion();
+          System.exit(0);
+        }
+      }
+    }
+
+    if (!debug_mode) {
+      Logger log = Logger.getLogger(ApplicationSettings.class.getName());
+      // Disable logging message whose level is less than WARNING.
+      Logger rootLogger = log.getParent();
+
+      for (Handler h : rootLogger.getHandlers()) {
+        h.setLevel(Level.WARNING);
+      }
+    }
+    return toOpen;
+  }
+
+  private static void usage() {
+    showVersion();
+    System.out.println(CurrentLocale.getString("HT.Options"));
+    System.out.println(CurrentLocale.getString("HT.File"));
+    System.out.println(CurrentLocale.getString("HT.Debug"));
+    System.out.println(CurrentLocale.getString("HT.Help"));
+    System.out.println(CurrentLocale.getString("HT.Reset"));
+    System.out.println(CurrentLocale.getString("HT.Version"));
+  }
+
+  public static void showVersion() {
+    System.out.println("EduMIPS64 version " + VERSION + " (codename: " + CODENAME + ", git revision " + GIT_REVISION + ", built on " + BUILD_DATE + ") - Ciao 'mbare.");
+  }
+}


### PR DESCRIPTION
See #199

This doesn't address the dependency on Main in the build file, since I'm not familiar enough with Gradle to confidently make the change there. It should remove the dependency from Java's standpoint though. I named the class ApplicationSettings since I had to move a few other fields (VERSION, BUILD_DATE, etc.) into the class, so it's a little more than just argument parsing.