### PR TITLE
Do not incorrectly overwrite EX if FP was executed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 ###############################################################################
 ## Custom directives.
 
+# Assembly files. We'll never store those in the root directory of the
+# project,
+/*.s
+
 # Vim temporary files.
 *.un~
 *.sw*

--- a/src/main/java/org/edumips64/core/CPU.java
+++ b/src/main/java/org/edumips64/core/CPU.java
@@ -430,7 +430,7 @@ public class CPU {
       pc.writeDoubleWord((pc.getValue()) + 4);
 
     } catch (RAWException ex) {
-      if (currentPipeStage == Pipeline.Stage.ID) {
+      if (currentPipeStage == Pipeline.Stage.ID && pipe.EX() == null) {
         pipe.setEX(bubble);
       }
       RAWStalls++;

--- a/src/main/java/org/edumips64/core/fpu/FPPipeline.java
+++ b/src/main/java/org/edumips64/core/fpu/FPPipeline.java
@@ -24,6 +24,9 @@
  */
 
 package org.edumips64.core.fpu;
+
+import org.edumips64.core.fpu.FPPipeline.Constants.FPAdderStatus;
+import org.edumips64.core.fpu.FPPipeline.Constants.FPMultiplierStatus;
 import org.edumips64.core.is.*;
 
 import java.util.*;
@@ -117,38 +120,43 @@ public class FPPipeline {
    *      ADDER [1,4], MULTIPLIER [1,7], DIVIDER [any] */
 
   public InstructionInterface getInstructionByFuncUnit(String funcUnit, int stage) {
-    if (funcUnit.compareToIgnoreCase("ADDER") == 0)
+    if (funcUnit.compareToIgnoreCase("ADDER") == 0) {
+      Map<FPAdderStatus, InstructionInterface> adderFu = adder.getFuncUnit();
+    
       switch (stage) {
       case 1:
-        return (adder.getFuncUnit().get(Constants.FPAdderStatus.A1));
+        return adderFu.get(Constants.FPAdderStatus.A1);
       case 2:
-        return (adder.getFuncUnit().get(Constants.FPAdderStatus.A2));
+        return adderFu.get(Constants.FPAdderStatus.A2);
       case 3:
-        return (adder.getFuncUnit().get(Constants.FPAdderStatus.A3));
+        return adderFu.get(Constants.FPAdderStatus.A3);
       case 4:
-        return (adder.getFuncUnit().get(Constants.FPAdderStatus.A4));
+        return adderFu.get(Constants.FPAdderStatus.A4);
       }
+    }
 
-    if (funcUnit.compareToIgnoreCase("MULTIPLIER") == 0)
+    if (funcUnit.compareToIgnoreCase("MULTIPLIER") == 0) {
+      Map<FPMultiplierStatus, InstructionInterface> multiplierFu = multiplier.getFuncUnit();
       switch (stage) {
       case 1:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M1));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M1);
       case 2:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M2));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M2);
       case 3:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M3));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M3);
       case 4:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M4));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M4);
       case 5:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M5));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M5);
       case 6:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M6));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M6);
       case 7:
-        return (multiplier.getFuncUnit().get(Constants.FPMultiplierStatus.M7));
+        return multiplierFu.get(Constants.FPMultiplierStatus.M7);
       }
+    }
 
     if (funcUnit.compareToIgnoreCase("DIVIDER") == 0) {
-      return (divider.getFuncUnit());
+      return divider.getFuncUnit();
     }
 
     return null;

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -577,11 +577,11 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
 
   /* Issue #132:The longer the simulation goes on, the lower the simulation rate.
      This tests only part of the bug, since part of it is related to the GUI. */
-  @Test(timeout=5000)
+  @Test(timeout=20000)
   public void testHailStone() throws Exception {
     runMipsTestWithAndWithoutForwarding("hailstoneenglish.s");
   }
-  @Test(timeout=10000)
+  @Test(timeout=20000)
   public void testSetBitSort() throws Exception {
     runMipsTestWithAndWithoutForwarding("set-bit-sort.s");
   }

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -612,11 +612,7 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Issue #304: Infinite RAW stall in floating-point.
-     NOTE: there are 2 bugs in issue #304, for now only one is fixed. There is still
-     an incorrect representation on cycles (caught by this unit test as well): will
-     remove the expected exception once the second bug is fixed.
   */
-  @Test(expected = InvalidCycleElementTransactionException.class)
   public void testIssue304() throws Exception {
     runMipsTest("issue304.s", false, 30);
   }

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -274,19 +274,19 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Test for the instruction BREAK */
-  @Test(expected = BreakException.class)
+  @Test(expected = BreakException.class, timeout=1000)
   public void testBREAK() throws Exception {
     runMipsTest("break.s");
   }
 
   /* Test for r0 */
-  @Test
+  @Test(timeout=1000)
   public void testR0() throws Exception {
     runMipsTest("zero.s");
   }
 
   /* Test instruction and cycle count for the simplest valid program. */
-  @Test
+  @Test(timeout=1000)
   public void testHalt() throws Exception {
       CpuTestStatus status = runMipsTest("halt.s");
 
@@ -298,97 +298,97 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Tests for instruction SYSCALL. */
-  @Test(expected = BreakException.class)
+  @Test(expected = BreakException.class, timeout=1000)
   public void testOpenNonExistent() throws Exception {
     runMipsTest("test-open-nonexistent.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testOpenExistent() throws Exception {
     runMipsTest("test-open-existent.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testReadWriteFile() throws Exception {
     // TODO(andrea): clean up the test file.
     runMipsTest("read-write.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testPrintf() throws Exception {
     runMipsTest("hello-world.s");
     assertEquals("9th of July:\nEduMIPS64 version 1.2 is being tested! 100% success!", stdOut.toString());
   }
 
   /* Test for instruction B */
-  @Test
+  @Test(timeout=1000)
   public void testB() throws Exception {
     runMipsTest("b.s");
   }
 
   /* Test for instruction DADDU */
-  @Test
+  @Test(timeout=1000)
   public void testDADDU() throws Exception {
     runMipsTest("daddu-simple-test.s");
 }
 
   /* Test for instruction DSUBU */
-  @Test
+  @Test(timeout=1000)
   public void testDSUBU() throws Exception {
         runMipsTest("dsubu-simple-test.s");
     }
 
   /* Test for instructions DMULU and DMULTU */
-  @Test
+  @Test(timeout=1000)
   public void testDMULU() throws Exception {
         runMipsTest("dmulu-simple-test.s");
     }
 
   /* Test for the instruction JAL */
-  @Test
+  @Test(timeout=1000)
   public void testJAL() throws Exception {
     runMipsTest("jal.s");
   }
 
   /* Test for instructions DIV, MFLO, MFHI */
-  @Test
+  @Test(timeout=1000)
   public void testDIV() throws Exception {
     runMipsTest("div.s");
   }
 
   /* Test for instruction DIVU */
-  @Test
+  @Test(timeout=1000)
   public void testDIVU() throws Exception {
     runMipsTest("divu.s");
   }
 
   /* Test for utils/strlen.s */
-  @Test
+  @Test(timeout=1000)
   public void testStrlen() throws Exception {
     runMipsTest("test-strlen.s");
   }
 
   /* Test for utils/strcmp.s */
-  @Test
+  @Test(timeout=1000)
   public void testStrcmp() throws Exception {
     runMipsTest("test-strcmp.s");
   }
 
   /* Tests for the memory */
-  @Test
+  @Test(timeout=1000)
   public void testMemory() throws Exception {
     runMipsTest("memtest.s");
   }
 
   /* Read-after-write test */
-  @Test
+  @Test(timeout=1000)
   public void testRAW() throws Exception {
     runMipsTestWithAndWithoutForwarding("raw.s");
   }
 
   /* Forwarding test. The number of cycles is hardcoded and depends on the
    * contents of forwarding.s */
-  @Test
+  @Test(timeout=1000)
   public void testForwarding() throws Exception {
     // Simple test.
     runForwardingTest("forwarding.s", 15, 18, 10);
@@ -398,13 +398,13 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     runForwardingTest("forwarding-hp-pA18.s", 8, 12, 4);
   }
 
-  @Test
+  @Test(timeout=1000)
   public void storeAfterLoad() throws Exception {
     runMipsTest("store-after-load.s");
   }
 
   /* ------- FPU TESTS -------- */
-  @Test
+  @Test(timeout=1000)
   public void testFPUStalls() throws Exception {
     String filename = "fpu-waw.s";
     Map<ForwardingStatus, CpuTestStatus> statuses = runMipsTestWithAndWithoutForwarding(filename);
@@ -422,7 +422,7 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     collector.checkThat(filename + ": RAW stalls without forwarding.", statuses.get(ForwardingStatus.DISABLED).rawStalls, equalTo(2));
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testFPUMul() throws Exception {
     // This test contains code that raises exceptions, let's disable them.
     config.putBoolean(ConfigKey.FP_INVALID_OPERATION, false);
@@ -441,47 +441,47 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     collector.checkThat(statuses.get(ForwardingStatus.DISABLED).memStalls, equalTo(expected_mem_stalls));
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testFPCond() throws Exception {
     runMipsTest("fp-cond.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testSubtraction() throws Exception {
     runMipsTest("sub.d.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testDivision() throws Exception {
     runMipsTest("div.d.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testDividerStalls() throws Exception {
     CpuTestStatus status = runMipsTest("div.d.divider-stalls.s");
     assertEquals(status.divStalls, 23);
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testOutOfOrder() throws Exception {
     CpuTestStatus status = runMipsTest("fpu-out-of-order-terminate.s");
     assertEquals(2, Integer.parseInt(status.fpRegisters[2].getBinString(), 2));
   }
 
   /* Tests for masking synchronous exceptions. Termination cannot be tested here since it's in the CPUSwingWorker. */
-  @Test(expected = SynchronousException.class)
+  @Test(expected = SynchronousException.class, timeout=1000)
   public void testDivisionByZeroThrowException() throws Exception {
     config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, false);
     runMipsTest("div0.s");
   }
 
   /* Test for Out Of Memory while loading a file with more data than the memory can fit. */
-  @Test(expected = ParserMultiException.class)
+  @Test(expected = ParserMultiException.class, timeout=1000)
   public void testOom() throws Exception {
     runMipsTest("oom.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testDivisionByZeroNoThrowException() throws Exception {
     config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, true);
     runMipsTest("div0.s");
@@ -489,65 +489,65 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
 
   /* ------- REGRESSION TESTS -------- */
   /* Issue #7 */
-  @Test
+  @Test(timeout=1000)
   public void testMovnIssue7() throws Exception {
     runMipsTest("movn-issue-7.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testMovzIssue7() throws Exception {
     runMipsTest("movz-issue-7.s");
   }
 
   /* Issue #2: Misaligned memory operations are not handled correctly */
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignLD() throws Exception {
     runMipsTest("misaligned-ld.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignSD() throws Exception {
     runMipsTest("misaligned-sd.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignLW() throws Exception {
     runMipsTest("misaligned-lw.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignLWU() throws Exception {
     runMipsTest("misaligned-lwu.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignSW() throws Exception {
     runMipsTest("misaligned-sw.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignLH() throws Exception {
     runMipsTest("misaligned-lh.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignLHU() throws Exception {
     runMipsTest("misaligned-lhu.s");
   }
 
-  @Test(expected = NotAlignException.class)
+  @Test(expected = NotAlignException.class, timeout=1000)
   public void testMisalignSH() throws Exception {
     runMipsTest("misaligned-sh.s");
   }
 
-  @Test
+  @Test(timeout=1000)
   public void testAligned() throws Exception {
     runMipsTest("aligned.s");
   }
 
   /* Issue #28: Dinero tracefile tracks both Load and Store memory accesses as
    * read. */
-  @Test
+  @Test(timeout=1000)
   public void testTracefile() throws Exception {
     runTestAndCompareTracefileWithGolden("tracefile-ld.s");
     runTestAndCompareTracefileWithGolden("tracefile-ldst.s");
@@ -556,20 +556,20 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Issue #36: StringIndexOutOfBoundsException raised at run-time. */
-  @Test(expected = AddressErrorException.class)
+  @Test(expected = AddressErrorException.class, timeout=1000)
   public void testNegativeAddress() throws Exception {
     runMipsTest("negative-address-issue-36.s");
   }
 
   /* Issue #51: Problem with SYSCALL 0 after branch. */
-  @Test
+  @Test(timeout=1000)
   public void testTerminationInID() throws Exception {
     runForwardingTest("issue51-halt.s", 11, 17, 6);
     runForwardingTest("issue51-syscall0.s", 11, 17, 6);
   }
 
   /* Issue #68: JR does not respect RAW stalls. */
-  @Test
+  @Test(timeout=1000)
   public void testRAWForRTypeFlowControl() throws Exception {
     runMipsTestWithAndWithoutForwarding("jr-raw.s");
     runMipsTestWithAndWithoutForwarding("jalr-raw.s");
@@ -577,42 +577,43 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
 
   /* Issue #132:The longer the simulation goes on, the lower the simulation rate.
      This tests only part of the bug, since part of it is related to the GUI. */
-  @Test
+  @Test(timeout=5000)
   public void testHailStone() throws Exception {
     runMipsTestWithAndWithoutForwarding("hailstoneenglish.s");
   }
-  @Test
+  @Test(timeout=10000)
   public void testSetBitSort() throws Exception {
     runMipsTestWithAndWithoutForwarding("set-bit-sort.s");
   }
 
   /* Issue #175: While parsing LW and SW instructions, offset cannot be negative
      or above 8192 */
-  @Test
+  @Test(timeout=1000)
   public void testLargeOffsets() throws Exception {
     runMipsTestWithAndWithoutForwarding("large-offsets.s");
   }
-  @Test
+  @Test(timeout=1000)
   public void testNegativeOffsets() throws Exception {
     runMipsTestWithAndWithoutForwarding("negative-offsets.s");
   }
 
   /* Issue #255: Trying to store a large memory location in an immediate field
      causes EduMIPS64 to crash */
-  @Test(expected = IntegerOverflowException.class)
+  @Test(expected = IntegerOverflowException.class, timeout=1000)
   public void testImmediateOverflow() throws Exception {
     runMipsTest("immediate-overflow.s");
   }
 
   /* Still issue #255 -- make sure that we can load large memory locations
      via ld/st instructions */
-  @Test()
+  @Test(timeout=1000)
   public void testLdLargeImmediate() throws Exception {
     runMipsTest("load-large-memory-location.s");
   }
 
   /* Issue #304: Infinite RAW stall in floating-point.
   */
+  @Test(timeout=1000)
   public void testIssue304() throws Exception {
     runMipsTest("issue304.s", false, 30);
   }

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -274,19 +274,19 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Test for the instruction BREAK */
-  @Test(expected = BreakException.class, timeout=1000)
+  @Test(expected = BreakException.class, timeout=2000)
   public void testBREAK() throws Exception {
     runMipsTest("break.s");
   }
 
   /* Test for r0 */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testR0() throws Exception {
     runMipsTest("zero.s");
   }
 
   /* Test instruction and cycle count for the simplest valid program. */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testHalt() throws Exception {
       CpuTestStatus status = runMipsTest("halt.s");
 
@@ -298,97 +298,97 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Tests for instruction SYSCALL. */
-  @Test(expected = BreakException.class, timeout=1000)
+  @Test(expected = BreakException.class, timeout=2000)
   public void testOpenNonExistent() throws Exception {
     runMipsTest("test-open-nonexistent.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testOpenExistent() throws Exception {
     runMipsTest("test-open-existent.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testReadWriteFile() throws Exception {
     // TODO(andrea): clean up the test file.
     runMipsTest("read-write.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testPrintf() throws Exception {
     runMipsTest("hello-world.s");
     assertEquals("9th of July:\nEduMIPS64 version 1.2 is being tested! 100% success!", stdOut.toString());
   }
 
   /* Test for instruction B */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testB() throws Exception {
     runMipsTest("b.s");
   }
 
   /* Test for instruction DADDU */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDADDU() throws Exception {
     runMipsTest("daddu-simple-test.s");
 }
 
   /* Test for instruction DSUBU */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDSUBU() throws Exception {
         runMipsTest("dsubu-simple-test.s");
     }
 
   /* Test for instructions DMULU and DMULTU */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDMULU() throws Exception {
         runMipsTest("dmulu-simple-test.s");
     }
 
   /* Test for the instruction JAL */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testJAL() throws Exception {
     runMipsTest("jal.s");
   }
 
   /* Test for instructions DIV, MFLO, MFHI */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDIV() throws Exception {
     runMipsTest("div.s");
   }
 
   /* Test for instruction DIVU */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDIVU() throws Exception {
     runMipsTest("divu.s");
   }
 
   /* Test for utils/strlen.s */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testStrlen() throws Exception {
     runMipsTest("test-strlen.s");
   }
 
   /* Test for utils/strcmp.s */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testStrcmp() throws Exception {
     runMipsTest("test-strcmp.s");
   }
 
   /* Tests for the memory */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testMemory() throws Exception {
     runMipsTest("memtest.s");
   }
 
   /* Read-after-write test */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testRAW() throws Exception {
     runMipsTestWithAndWithoutForwarding("raw.s");
   }
 
   /* Forwarding test. The number of cycles is hardcoded and depends on the
    * contents of forwarding.s */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testForwarding() throws Exception {
     // Simple test.
     runForwardingTest("forwarding.s", 15, 18, 10);
@@ -398,13 +398,13 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     runForwardingTest("forwarding-hp-pA18.s", 8, 12, 4);
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void storeAfterLoad() throws Exception {
     runMipsTest("store-after-load.s");
   }
 
   /* ------- FPU TESTS -------- */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testFPUStalls() throws Exception {
     String filename = "fpu-waw.s";
     Map<ForwardingStatus, CpuTestStatus> statuses = runMipsTestWithAndWithoutForwarding(filename);
@@ -422,7 +422,7 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     collector.checkThat(filename + ": RAW stalls without forwarding.", statuses.get(ForwardingStatus.DISABLED).rawStalls, equalTo(2));
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testFPUMul() throws Exception {
     // This test contains code that raises exceptions, let's disable them.
     config.putBoolean(ConfigKey.FP_INVALID_OPERATION, false);
@@ -441,47 +441,47 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     collector.checkThat(statuses.get(ForwardingStatus.DISABLED).memStalls, equalTo(expected_mem_stalls));
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testFPCond() throws Exception {
     runMipsTest("fp-cond.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testSubtraction() throws Exception {
     runMipsTest("sub.d.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDivision() throws Exception {
     runMipsTest("div.d.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDividerStalls() throws Exception {
     CpuTestStatus status = runMipsTest("div.d.divider-stalls.s");
     assertEquals(status.divStalls, 23);
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testOutOfOrder() throws Exception {
     CpuTestStatus status = runMipsTest("fpu-out-of-order-terminate.s");
     assertEquals(2, Integer.parseInt(status.fpRegisters[2].getBinString(), 2));
   }
 
   /* Tests for masking synchronous exceptions. Termination cannot be tested here since it's in the CPUSwingWorker. */
-  @Test(expected = SynchronousException.class, timeout=1000)
+  @Test(expected = SynchronousException.class, timeout=2000)
   public void testDivisionByZeroThrowException() throws Exception {
     config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, false);
     runMipsTest("div0.s");
   }
 
   /* Test for Out Of Memory while loading a file with more data than the memory can fit. */
-  @Test(expected = ParserMultiException.class, timeout=1000)
+  @Test(expected = ParserMultiException.class, timeout=2000)
   public void testOom() throws Exception {
     runMipsTest("oom.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testDivisionByZeroNoThrowException() throws Exception {
     config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, true);
     runMipsTest("div0.s");
@@ -489,65 +489,65 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
 
   /* ------- REGRESSION TESTS -------- */
   /* Issue #7 */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testMovnIssue7() throws Exception {
     runMipsTest("movn-issue-7.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testMovzIssue7() throws Exception {
     runMipsTest("movz-issue-7.s");
   }
 
   /* Issue #2: Misaligned memory operations are not handled correctly */
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignLD() throws Exception {
     runMipsTest("misaligned-ld.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignSD() throws Exception {
     runMipsTest("misaligned-sd.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignLW() throws Exception {
     runMipsTest("misaligned-lw.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignLWU() throws Exception {
     runMipsTest("misaligned-lwu.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignSW() throws Exception {
     runMipsTest("misaligned-sw.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignLH() throws Exception {
     runMipsTest("misaligned-lh.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignLHU() throws Exception {
     runMipsTest("misaligned-lhu.s");
   }
 
-  @Test(expected = NotAlignException.class, timeout=1000)
+  @Test(expected = NotAlignException.class, timeout=2000)
   public void testMisalignSH() throws Exception {
     runMipsTest("misaligned-sh.s");
   }
 
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testAligned() throws Exception {
     runMipsTest("aligned.s");
   }
 
   /* Issue #28: Dinero tracefile tracks both Load and Store memory accesses as
    * read. */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testTracefile() throws Exception {
     runTestAndCompareTracefileWithGolden("tracefile-ld.s");
     runTestAndCompareTracefileWithGolden("tracefile-ldst.s");
@@ -556,20 +556,20 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   }
 
   /* Issue #36: StringIndexOutOfBoundsException raised at run-time. */
-  @Test(expected = AddressErrorException.class, timeout=1000)
+  @Test(expected = AddressErrorException.class, timeout=2000)
   public void testNegativeAddress() throws Exception {
     runMipsTest("negative-address-issue-36.s");
   }
 
   /* Issue #51: Problem with SYSCALL 0 after branch. */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testTerminationInID() throws Exception {
     runForwardingTest("issue51-halt.s", 11, 17, 6);
     runForwardingTest("issue51-syscall0.s", 11, 17, 6);
   }
 
   /* Issue #68: JR does not respect RAW stalls. */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testRAWForRTypeFlowControl() throws Exception {
     runMipsTestWithAndWithoutForwarding("jr-raw.s");
     runMipsTestWithAndWithoutForwarding("jalr-raw.s");
@@ -588,32 +588,32 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
 
   /* Issue #175: While parsing LW and SW instructions, offset cannot be negative
      or above 8192 */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testLargeOffsets() throws Exception {
     runMipsTestWithAndWithoutForwarding("large-offsets.s");
   }
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testNegativeOffsets() throws Exception {
     runMipsTestWithAndWithoutForwarding("negative-offsets.s");
   }
 
   /* Issue #255: Trying to store a large memory location in an immediate field
      causes EduMIPS64 to crash */
-  @Test(expected = IntegerOverflowException.class, timeout=1000)
+  @Test(expected = IntegerOverflowException.class, timeout=2000)
   public void testImmediateOverflow() throws Exception {
     runMipsTest("immediate-overflow.s");
   }
 
   /* Still issue #255 -- make sure that we can load large memory locations
      via ld/st instructions */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testLdLargeImmediate() throws Exception {
     runMipsTest("load-large-memory-location.s");
   }
 
   /* Issue #304: Infinite RAW stall in floating-point.
   */
-  @Test(timeout=1000)
+  @Test(timeout=2000)
   public void testIssue304() throws Exception {
     runMipsTest("issue304.s", false, 30);
   }

--- a/src/test/java/org/edumips64/TestTookTooLongException.java
+++ b/src/test/java/org/edumips64/TestTookTooLongException.java
@@ -1,0 +1,5 @@
+package org.edumips64;
+
+public class TestTookTooLongException extends Exception {
+    private static final long serialVersionUID = 8262404487261194396L;
+}

--- a/src/test/resources/issue304.s
+++ b/src/test/resources/issue304.s
@@ -1,0 +1,37 @@
+; issue304.s - test file for EduMIPS64.
+;
+; Regression test for issue 308.
+;
+; Derived from the code provided by GitHub user @jcarletta in the same issue.
+;
+; (c) 2020 Andrea Spadaccini and the EduMIPS64 team
+;
+; This file is part of the EduMIPS64 project, and is released under the GNU
+; General Public License.
+; 
+; This program is free software; you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation; either version 2 of the License, or
+; (at your option) any later version.
+; 
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+; 
+; You should have received a copy of the GNU General Public License
+; along with this program; if not, write to the Free Software
+; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+.code
+    DADDI r2, r0, 1
+    ADD.D f1, f1, f1
+    ADD.D f2, f2, f2
+    NOP
+    DADDI r1, r0, 1
+    ADD.D f3, f2 ,f2
+    BNE r2, r1, error       ; In issue 304, this instruction is permanently in RAW because the second DADDI is mistakenly removed from the pipeline before it unlocks the read semaphore.
+    SYSCALL 0
+
+error:
+    BREAK


### PR DESCRIPTION
This PR fixes the first bug reported in issue #304, and starts tackling the problem of correctly representing out-of-order instructions in the Cycles UI.

It also add timeouts for end-to-end unit tests to detect infinite loops.