### PR TITLE
Prep version 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # EduMIPS64 ChangeLog
 
+## 1.2.8 () - ?
+### Added
+
+### Fixed
+
+### Changed
+
 ## 1.2.7 (11/04/2020) - Hope
 ### Fixed
 - RAW stall in combination with FPU caused instructions to disappear (Issue #304)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 application {
   mainClassName = "org.edumips64.Main"  
 }
-val codename = "Hope"
+val codename = "?"
 val version: String by project
 
 // Specify Java source/target version.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.7
+version=1.2.8


### PR DESCRIPTION
No intention to release any time soon, but at least jars will have version 1.2.8.