### PR TITLE
Initialize JS on GWT onModuleLoad event

### DIFF
--- a/src/main/java/org/edumips64/client/WebUi.java
+++ b/src/main/java/org/edumips64/client/WebUi.java
@@ -23,7 +23,9 @@
 package org.edumips64.client;
 
 import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.user.client.Command;
 
 import jsinterop.annotations.JsType;
 
@@ -203,8 +205,20 @@ public class WebUi implements EntryPoint {
 
   @Override
   public void onModuleLoad() {
-    info("Module loaded.");
+    // Invoke JS initialization logic that depends on this GWT module being loaded.
+    info("Module loaded, calling the global JS function onGwtReady()");
+    Scheduler.get().scheduleDeferred(new Command() {
+      public void execute() {
+        runOnGwtReady();
+      }
+    });
   }
+
+  private native void runOnGwtReady() /*-{
+    if (typeof $wnd.onGwtReady !== "undefined") {
+      $wnd.onGwtReady();
+    }
+  }-*/;
 
   public void init() {
     // Simulator initialization.

--- a/src/main/java/org/edumips64/client/ui.js
+++ b/src/main/java/org/edumips64/client/ui.js
@@ -126,16 +126,9 @@ const Simulator = (props) => {
     );
 }
 
-// Ugly hack to wait for GWT initialization to finish.
-// If initialization is not done, jsedumips64 will be undefined.
-// I tried a couple of different ways of doing this with sleeps,
-// this is a compromise between simplicity and user experience.
-//
-// The better way to handle this would be to somehow get a call
-// when GWT is initialized, which could be done by overriding
-// the WebUi.onModuleLoad() function.
-console.log("Waiting 500ms for GWT to initialize");
-setTimeout(() => {
+// This method is called by WebUI.onModuleLoad, a callback invoked by GWT when the module is loaded.
+// It's necessary to be called by GWT because before the module is loaded the GWT objects cannot be used.
+const onGwtReady = () => {
     let sim = new jsedumips64.WebUi();
     sim.init();
 
@@ -143,4 +136,5 @@ setTimeout(() => {
         <Simulator simulator={sim} />,
         document.getElementById('simulator')
     )
-}, 500);
+
+}


### PR DESCRIPTION
This removes ugly timeouts and guarantees clean initialization.