### PR TITLE
Call reset() on load

### DIFF
--- a/src/main/java/org/edumips64/client/ui.js
+++ b/src/main/java/org/edumips64/client/ui.js
@@ -112,6 +112,7 @@ const Simulator = (props) => {
 
     const loadCode = () => {
         console.log("Executing loadCode");
+        simulator.reset();
         const result = simulator.loadProgram(code);
         updateState(result);
         console.log(result);


### PR DESCRIPTION
This effectively resets the simulator state before loading a program.

Closes #338.