### PR TITLE
Mark parsing errors in Web UI editor

### DIFF
--- a/src/main/java/org/edumips64/client/ParserError.java
+++ b/src/main/java/org/edumips64/client/ParserError.java
@@ -1,0 +1,45 @@
+package org.edumips64.client;
+
+import org.edumips64.core.parser.ParserException;
+
+import jsinterop.annotations.JsIgnore;
+import jsinterop.annotations.JsType;
+
+@JsType
+public class ParserError {
+    public int row;
+    public int column;
+    public boolean isWarning;
+    public String description;
+
+    @JsIgnore
+    private ParserError(int row, int column, boolean isWarning, String description) {
+        this.row = row;
+        this.column = column;
+        this.isWarning = isWarning;
+        this.description = description;
+    }
+
+    @JsIgnore
+    public String asSerializedJsonString() {
+        FluentJsonObject json = new FluentJsonObject();
+        return json
+            .put("row", row)
+            .put("column", column)
+            .put("isWarning", isWarning)
+            .put("description", description)
+            .toString();
+    }
+
+    @JsIgnore
+    public static ParserError FromParserException(ParserException e) {
+        // Gets row, column, line, description.
+        String[] exceptionData = e.getStringArray();
+        return new ParserError(
+            Integer.parseInt(exceptionData[0]),
+            Integer.parseInt(exceptionData[1]),
+            !e.isError(),
+            exceptionData[3]);
+    }
+    
+}

--- a/src/main/java/org/edumips64/client/ParserError.java
+++ b/src/main/java/org/edumips64/client/ParserError.java
@@ -2,9 +2,22 @@ package org.edumips64.client;
 
 import org.edumips64.core.parser.ParserException;
 
-import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+
+class ParserErrorFactory {
+    public static ParserError FromParserException(ParserException e) {
+        // Gets row, column, line, description.
+        String[] exceptionData = e.getStringArray();
+
+        ParserError p = new ParserError();
+        p.row = Integer.parseInt(exceptionData[0]);
+        p.column = Integer.parseInt(exceptionData[1]);
+        p.isWarning = !e.isError();
+        p.description = exceptionData[3];
+        return p;
+    }
+}
 
 @JsType(namespace=JsPackage.GLOBAL, name="Object", isNative=true)
 public class ParserError {
@@ -12,35 +25,4 @@ public class ParserError {
     public int column;
     public boolean isWarning;
     public String description;
-
-    @JsIgnore
-    private ParserError(int row, int column, boolean isWarning, String description) {
-        this.row = row;
-        this.column = column;
-        this.isWarning = isWarning;
-        this.description = description;
-    }
-
-    @JsIgnore
-    public String asSerializedJsonString() {
-        FluentJsonObject json = new FluentJsonObject();
-        return json
-            .put("row", row)
-            .put("column", column)
-            .put("isWarning", isWarning)
-            .put("description", description)
-            .toString();
-    }
-
-    @JsIgnore
-    public static ParserError FromParserException(ParserException e) {
-        // Gets row, column, line, description.
-        String[] exceptionData = e.getStringArray();
-        return new ParserError(
-            Integer.parseInt(exceptionData[0]),
-            Integer.parseInt(exceptionData[1]),
-            !e.isError(),
-            exceptionData[3]);
-    }
-    
 }

--- a/src/main/java/org/edumips64/client/ParserError.java
+++ b/src/main/java/org/edumips64/client/ParserError.java
@@ -3,9 +3,10 @@ package org.edumips64.client;
 import org.edumips64.core.parser.ParserException;
 
 import jsinterop.annotations.JsIgnore;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
-@JsType
+@JsType(namespace=JsPackage.GLOBAL, name="Object", isNative=true)
 public class ParserError {
     public int row;
     public int column;

--- a/src/main/java/org/edumips64/client/Pipeline.java
+++ b/src/main/java/org/edumips64/client/Pipeline.java
@@ -23,9 +23,10 @@
  */
 package org.edumips64.client;
 
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
-@JsType
+@JsType(namespace=JsPackage.GLOBAL, name="Object", isNative=true)
 public class Pipeline {
     public Instruction IF;
     public Instruction ID;

--- a/src/main/java/org/edumips64/client/Result.java
+++ b/src/main/java/org/edumips64/client/Result.java
@@ -24,6 +24,7 @@
  */
 package org.edumips64.client;
 
+import elemental2.core.JsArray;
 import jsinterop.annotations.JsType;
 
 @JsType
@@ -36,6 +37,7 @@ public class Result {
   public String statistics = "";
   public Pipeline pipeline;
   public boolean encounteredBreak = false;
+  public JsArray<ParserError> parsingErrors;
 
   public Result(boolean success, String errorMessage) {
     this.success = success;

--- a/src/main/java/org/edumips64/client/ResultFactory.java
+++ b/src/main/java/org/edumips64/client/ResultFactory.java
@@ -36,6 +36,9 @@ import org.edumips64.core.CPU.CPUStatus;
 import org.edumips64.core.Pipeline.Stage;
 import org.edumips64.core.fpu.RegisterFP;
 import org.edumips64.core.is.InstructionInterface;
+import org.edumips64.core.parser.ParserMultiException;
+
+import jsinterop.base.Js;
 
 public class ResultFactory {
     private CPU cpu;
@@ -67,6 +70,12 @@ public class ResultFactory {
     public Result Failure(String errorMessage) {
         Result r = new Result(false, errorMessage);
         return AddCpuInfo(r);
+    }
+
+    public static Result AddParserErrors(Result result, ParserMultiException e) {
+        result.parsingErrors = Js.cast(e.getExceptionList().stream()
+            .map(exception -> ParserError.FromParserException(exception)).toArray(ParserError[]::new));
+        return result;
     }
 
     private Result AddCpuInfo(Result r) {

--- a/src/main/java/org/edumips64/client/ResultFactory.java
+++ b/src/main/java/org/edumips64/client/ResultFactory.java
@@ -74,7 +74,7 @@ public class ResultFactory {
 
     public static Result AddParserErrors(Result result, ParserMultiException e) {
         result.parsingErrors = Js.cast(e.getExceptionList().stream()
-            .map(exception -> ParserError.FromParserException(exception)).toArray(ParserError[]::new));
+            .map(exception -> ParserErrorFactory.FromParserException(exception)).toArray(ParserError[]::new));
         return result;
     }
 

--- a/src/main/java/org/edumips64/client/Simulator.java
+++ b/src/main/java/org/edumips64/client/Simulator.java
@@ -35,6 +35,7 @@ import org.edumips64.core.is.BreakException;
 import org.edumips64.core.is.HaltException;
 import org.edumips64.core.is.InstructionBuilder;
 import org.edumips64.core.parser.Parser;
+import org.edumips64.core.parser.ParserMultiException;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.InMemoryConfigStore;
 import org.edumips64.utils.io.FileUtils;
@@ -113,9 +114,11 @@ public class Simulator {
     try {
       parser.doParsing(code);
       dinero.setDataOffset(memory.getInstructionsNumber()*4);
-    } catch (Exception e) {
+    } catch (ParserMultiException e) {
       warning("Parsing error: " + e.toString());
-      return resultFactory.Failure(e.toString());
+      Result result = resultFactory.Failure("Parsing errors.");
+      result = ResultFactory.AddParserErrors(result, e);
+      return result;
     }
     cpu.setStatus(CPU.CPUStatus.RUNNING);
     info("Program parsed.");

--- a/src/main/java/org/edumips64/client/Simulator.java
+++ b/src/main/java/org/edumips64/client/Simulator.java
@@ -105,10 +105,8 @@ public class Simulator {
   }
 
   public Result loadProgram(String code) {
-    if (cpu.getStatus() != CPU.CPUStatus.READY) {
-      info("Resetting CPU before loading a new program.");
-      reset();
-    }
+    info("Resetting CPU before loading a new program.");
+    reset();
 
     info("Loading program: " + code);
     try {

--- a/src/main/java/org/edumips64/client/Worker.java
+++ b/src/main/java/org/edumips64/client/Worker.java
@@ -36,6 +36,7 @@ import com.google.gwt.core.client.EntryPoint;
 
 import elemental2.dom.DomGlobal;
 import elemental2.dom.MessageEvent;
+import static elemental2.core.Global.JSON;
 
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
@@ -59,20 +60,21 @@ public class Worker implements EntryPoint {
         String method = data.getAsAny("method").asString().toLowerCase();
         switch(method) {
           case "reset":
-            DomGlobal.postMessage(simulator.reset());
+            postMessage(simulator.reset());
             break;
           case "step":
             int steps = data.getAsAny("steps").asInt();
             info("steps: " + steps);
-            DomGlobal.postMessage(simulator.step(steps));
+            postMessage(simulator.step(steps));
             break;
           case "load":
             String code = data.getAsAny("code").asString();
             Result parseResult = simulator.loadProgram(code);
             if (!parseResult.success) {
-              DomGlobal.postMessage(parseResult);
+              DomGlobal.console.log(parseResult);
+              postMessage(parseResult);
             } else {
-              DomGlobal.postMessage(simulator.step(1));
+              postMessage(simulator.step(1));
             }
             break;
           default:
@@ -80,6 +82,10 @@ public class Worker implements EntryPoint {
         }
       }
     });
+  }
+
+  private void postMessage(Object message) {
+    DomGlobal.postMessage(message);
   }
 
   private void info(String message) {

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -1209,14 +1209,17 @@ public class Parser {
     }
   }
 
-  /** Clean multiple tab or spaces in a bad format String //and converts  this String to upper case
-   *  @param s the bad format String
+  /** Clean multiple tab or spaces in a badly formatted String. 
+   *  @param s the badly formatted String
    *  @return the cleaned String
    */
   private String cleanFormat(String s) {
+    if (s == null) {
+      logger.warning("Null string passed to cleanFormat, returning an empty string.");
+      return "";
+    }
+
     if (s.length() > 0 && s.charAt(0) != ';' &&  s.charAt(0) != '\n') {
-      //String[] nocomment=s.split(";");
-      //s=nocomment[0];//.toUpperCase();
       s = s.trim();
       s = s.replace("\t", " ");
 
@@ -1232,7 +1235,7 @@ public class Parser {
       }
     }
 
-    return null;
+    return "";
   }
 
   /** Check if is a valid string for a register

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -18,6 +18,7 @@ const Simulator = ({sim, initialState}) => {
     const [code, setCode] = React.useState(SampleProgram);
     const [status, setStatus] = React.useState(initialState.status);
     const [pipeline, setPipeline] = React.useState(initialState.pipeline);
+    const [parsingErrors, setParsingErrors] = React.useState(initialState.parsingErrors);
 
     // Number of steps left to run. Used to keep track of execution.
     // If set to -1, runs until the execution ends.
@@ -35,21 +36,21 @@ const Simulator = ({sim, initialState}) => {
     const simulatorRunning = status == "RUNNING";
 
     sim.onmessage = (e) => {
-        console.log("Got message from worker");
         const result = sim.parseResult(e.data);
-        console.log(result);
+        console.log("Got message from worker.", result);
         updateState(result);
     }
 
     const updateState = (result) => {
         console.log("Updating state.");
+
         setExecuting(false);
-        console.log(result);
         setRegisters(result.registers);
         setMemory(result.memory);
         setStats(result.statistics);
         setStatus(result.status);
         setPipeline(result.pipeline);
+        setParsingErrors(result.parsingErrors);
 
         if (!result.success) {
             alert(result.errorMessage);
@@ -95,6 +96,7 @@ const Simulator = ({sim, initialState}) => {
                 onStopClick={() => {setMustStop(true)}} stopEnabled={executing}
                 onChangeValue={(text) => setCode(text)} 
                 code={code}
+                parsingErrors={parsingErrors}
             />
             <Registers {...registers}/>
             <Memory memory={memory}/>


### PR DESCRIPTION
Basic version, barely working.

TODO (in different PRs)

* handle multiple errors in the same line (#385)
* fix parsing error start/end (#383)
* add a nice indicator of error presence and # of warnings/errors (#384)
* check syntax while the user types (every second or so) (#386)