### PR TITLE
Minor style fixes for memory textarea

### DIFF
--- a/src/webapp/static/index.html
+++ b/src/webapp/static/index.html
@@ -2,13 +2,14 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <title>EduMIPS64 Experimental Web Frontend</title>
-      <link rel="stylesheet" media="screen" type="text/css" href="style.css">
       <link rel="icon" type="image/png" href="favicon.png">
 
        <!-- Materialize.CSS -->
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
-      <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" >
       <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+
+      <link rel="stylesheet" media="screen" type="text/css" href="style.css">
 
       <!-- Materialize JS initialization code -->
       <script type="text/javascript" language="javascript">

--- a/src/webapp/static/style.css
+++ b/src/webapp/static/style.css
@@ -33,6 +33,7 @@ textarea {
     width: 100%;
     height: 100%;
     border: 0;
+    color: rgba(0,0,0,0.87)
 }
 
 /* Registers table */


### PR DESCRIPTION
A couple of style fixes to the memory textarea (I know there are better plans for that as per #344, but in the meantime...): 
- invert the CSS order so that `width:100% height:100%` in style.css is applied to the textarea element (now it's rendered shrunk)
- use same text color as in the other elements, which is set by materialize.css (now it's black)

---

Unrelated to this PR, some feedback on the Web UI:
 - it's pretty cool, good job! :+1: 
 - the Monaco editor is quite heavy: it makes the js bundle about 2.7MB, from just 300kB with a simple textarea instead... I wonder if there's any way to make it slimmer (or use Ace or something [else](https://en.wikipedia.org/wiki/Comparison_of_JavaScript-based_source_code_editors)) :thinking: 
 - etc (other stuff, but no need to be too picky on a prototype :smiley: )