### PR TITLE
Fix recursive update in useEffect

### DIFF
--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -49,7 +49,7 @@ const Code = (props) => {
             },
         });
         setHoverCleanup(disposable);
-    }, [props.parsedInstructions, monaco, hoverDisposable]);
+    }, [props.parsedInstructions, monaco]); // eslint-disable-line react-hooks/exhaustive-deps
 
 
     const editorDidMount = (editor, monaco) => {


### PR DESCRIPTION
The callback modified hoverCleanups, but also depended on it, which
generated an infinite update loop.