### PR TITLE
Set minimum editor widget height

### DIFF
--- a/src/webapp/static/style.css
+++ b/src/webapp/static/style.css
@@ -23,9 +23,10 @@ nav {
 }
 
 /* The React Monaco Editor container doesn't work well with padding,
-   and also has some built-in padding. removing it. */
+   and also has some built-in padding. removing it. Also, set min height. */
 #widgetGrid > div.react-monaco-editor-container {
   padding: 0px;
+  min-height: 500px;
 }
 
 textarea {


### PR DESCRIPTION
This will prevent the editor from collapsing to 0px height if the initial layout is a 1-column grid, which happens on mobile.