### PR TITLE
Remove no-deps JAR

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,9 +45,7 @@ jobs:
         run: ./gradlew allDocs
 
       # Build JAR files.
-      - name: Build standalone JAR
-        run: ./gradlew standaloneJar
-      - name: Build slim JAR
+      - name: Build JAR
         run: ./gradlew jar
       - name: Build CLI JAR
         run: ./gradlew cliJar
@@ -64,13 +62,7 @@ jobs:
           name: Italian manual (PDF)
           path: ./build/docs/it/latex/EduMIPS64.pdf
 
-      - name: Upload Standalone JAR
-        uses: actions/upload-artifact@v1.0.0
-        with:
-          name: Standalone JAR
-          path: ./build/libs/edumips64-${{ steps.read_version.outputs.value }}-standalone.jar
-
-      - name: Upload Slim JAR
+      - name: Upload JAR
         uses: actions/upload-artifact@v1.0.0
         with:
           name: Slim JAR

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Upload JAR
         uses: actions/upload-artifact@v1.0.0
         with:
-          name: Slim JAR
+          name: JAR
           path: ./build/libs/edumips64-${{ steps.read_version.outputs.value }}.jar
 
       - name: Upload CLI JAR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # EduMIPS64 ChangeLog
 
+## 1.2.8 ()
+### Changed
+- EduMIPS64 now uses Java 11, to benefit from modern Java features
+- Adopted picocli for command-line options
+- Removed the JAR with no bundled dependencies, since start-up now depends on picocli
+
+### Fixed
+- Factor out the argv parsing logic (Issue #199)
+
 ## 1.2.7.1 (13/04/2020) - Hope
 ### Fixed
 - div.d incorrectly emits SEVERE logging statement (Issue #315)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -65,9 +65,8 @@ Individual tasks for building single documentation (PDF and HTML) and jar target
 are available too: please read `build.gradle` for the complete list.  
 Gradle builds the following jar artifacts:
 
-- `edumips64-<version>-standalone.jar`: GUI executable jar including the JavaHelp dependency
-- `edumips64-<version>.jar`: GUI executable jar
-- `edumips64-<version>-cli.jar`: CLI executable jar
+- `edumips64-<version>.jar`: GUI executable jar (includes JavaHelp and picocli)
+- `edumips64-<version>-cli.jar`: CLI executable jar (includes picocli)
 
 Gradle is supported by all the main Java IDEs (e.g. IDEA, Eclipse, NetBeans).
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -206,7 +206,7 @@ be automated, but before that is done those checks should be done manually.
   - verify that the version number, code name, build date and git ID are correct
   - open one .s file (e.g., `div.d.s`)
   - run it
-  - if it's the standalone JAR, open the help
+  - open the help
   - close the application
   - verify the JAR size (should be < 3 MB)
 - open the English manual and check the version

--- a/scripts/edumips64-snap-wrapper.sh
+++ b/scripts/edumips64-snap-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -jar -Djava.util.prefs.userRoot="$SNAP_USER_DATA" $SNAP/jar/edumips64-1.2.7.1-standalone.jar
+java -jar -Djava.util.prefs.userRoot="$SNAP_USER_DATA" $SNAP/jar/edumips64-1.2.7.1.jar

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,7 @@ parts:
     plugin: gradle
     source: https://github.com/edumips64/edumips64.git
     gradle-version: '6.3'
-    gradle-options: [standaloneJar]
+    gradle-options: [jar]
     override-build: |
       pip3 install -r docs/requirements.txt -U
       snapcraftctl build


### PR DESCRIPTION
Start-up now depends on PicoCLI anyway, so it's not practical to have
a JAR with no embedded dependencies.

Also update the CHANGELOG and the developer guide.