### PR TITLE
fix: fix issue 475 and clean up some minor warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,6 +193,9 @@ tasks.create<Jar>("noHelpJar"){
 /*
  * Code coverage report tasks
  */
+jacoco {
+    toolVersion = "0.8.6"
+}
 tasks.jacocoTestReport {
     reports {
         xml.isEnabled = true

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -213,3 +213,11 @@ be automated, but before that is done those checks should be done manually.
 - open the English manual and check the version
 - open the Italian manual and check the version
 - check the 'edge' snap and promote it to stable if it works (https://snapcraft.io/edumips64/releases, needs login)
+
+### Overriding instruction field values
+
+Many instruction class contain static fields. This can be confusing and error-prone. If a concrete instruction
+defines any fields that are defined in parent classes (such as, for example, `OPCODE_VALUE`), it is important that
+the constructor also overrides the value of the same attribute for the superclass, or some methods will not work properly.
+
+This is clearly too convoluted and should be redesigned in a way that makes it impossible to make mistakes.

--- a/src/main/java/org/edumips64/core/is/ADDI.java
+++ b/src/main/java/org/edumips64/core/is/ADDI.java
@@ -37,12 +37,12 @@ import org.edumips64.core.IrregularStringOfBitsException;
  */
 
 class ADDI extends ALU_IType {
-  private final String OPCODE_VALUE = "001000";
   ADDI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001000";
     this.name = "ADDI";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException {
     //getting strings from temporary registers
     String imm = TR[IMM_FIELD].getBinString();

--- a/src/main/java/org/edumips64/core/is/ADDIU.java
+++ b/src/main/java/org/edumips64/core/is/ADDIU.java
@@ -40,12 +40,12 @@ import org.edumips64.core.IrregularWriteOperationException;
  */
 
 class ADDIU extends ALU_IType {
-  private final String OPCODE_VALUE = "001001";
   ADDIU() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001001";
     this.name = "ADDIU";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     String imm = TR[IMM_FIELD].getBinString();

--- a/src/main/java/org/edumips64/core/is/ALU_IType.java
+++ b/src/main/java/org/edumips64/core/is/ALU_IType.java
@@ -64,9 +64,7 @@ public abstract class ALU_IType extends ComputationalInstructions {
    * @throws IntegerOverflowException
    */
   protected void checkImmediateForOverflow() throws IntegerOverflowException {
-    int immediateValue = params.get(IMM_FIELD);
-    if (immediateValue > IMM_FIELD_MAX) {
-      logger.log(Level.SEVERE, "The value {0} of the immediate field {1} exceeds the maximum allowed value {2}.", new Object[]{immediateValue, IMM_FIELD, IMM_FIELD_MAX});
+    if (params.get(IMM_FIELD) > IMM_FIELD_MAX) {
       throw new IntegerOverflowException();
     }
   }

--- a/src/main/java/org/edumips64/core/is/ALU_IType.java
+++ b/src/main/java/org/edumips64/core/is/ALU_IType.java
@@ -29,6 +29,7 @@ import org.edumips64.core.MemoryElementNotFoundException;
 import org.edumips64.core.Register;
 import org.edumips64.core.fpu.FPInvalidOperationException;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** This is the base class for all the immediate ALU instructions
@@ -38,15 +39,17 @@ import java.util.logging.Logger;
 public abstract class ALU_IType extends ComputationalInstructions {
   protected final static int RT_FIELD = 0;
   protected final static int RS_FIELD = 1;
-  protected final static int IMM_FIELD = 2;
-  private final static int RT_FIELD_INIT = 11;
-  private final static int RS_FIELD_INIT = 6;
-  private final static int IMM_FIELD_INIT = 16;
-  private final static int RT_FIELD_LENGTH = 5;
-  private final static int RS_FIELD_LENGTH = 5;
-  private final static int IMM_FIELD_LENGTH = 16;
-  private final static int IMM_FIELD_MAX = (int) Math.pow(2, IMM_FIELD_LENGTH - 1) - 1;
+  protected final static int RT_FIELD_INIT = 11;
+  protected final static int RS_FIELD_INIT = 6;
+  protected final static int IMM_FIELD_INIT = 16;
+  protected final static int RT_FIELD_LENGTH = 5;
+  protected final static int RS_FIELD_LENGTH = 5;
+  protected final static int IMM_FIELD_LENGTH = 16;
+  protected final static int IMM_FIELD_MAX = (int) Math.pow(2, IMM_FIELD_LENGTH - 1) - 1;
   protected String OPCODE_VALUE = "";
+
+  // Needs to be mutable because LUI's syntax is %R,%I, and IMM_FIELD will be 1 in that case.
+  protected static int IMM_FIELD = 2;
 
   private static final Logger logger = Logger.getLogger(ALU_IType.class.getName());
 
@@ -61,7 +64,9 @@ public abstract class ALU_IType extends ComputationalInstructions {
    * @throws IntegerOverflowException
    */
   protected void checkImmediateForOverflow() throws IntegerOverflowException {
-    if (params.get(IMM_FIELD) > IMM_FIELD_MAX) {
+    int immediateValue = params.get(IMM_FIELD);
+    if (immediateValue > IMM_FIELD_MAX) {
+      logger.log(Level.SEVERE, "The value {0} of the immediate field {1} exceeds the maximum allowed value {2}.", new Object[]{immediateValue, IMM_FIELD, IMM_FIELD_MAX});
       throw new IntegerOverflowException();
     }
   }

--- a/src/main/java/org/edumips64/core/is/ANDI.java
+++ b/src/main/java/org/edumips64/core/is/ANDI.java
@@ -41,14 +41,14 @@ import org.edumips64.core.fpu.FPInvalidOperationException;
   * @author Trubia Massimo, Russo Daniele
  */
 class ANDI extends ALU_IType {
-  private final String OPCODE_VALUE = "001100";
-
   ANDI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001100";
     this.name = "ANDI";
   }
+  
   //since this operation is carried out with zero padding of immediate, against sign_extend(immediate) methodology
   //of all others instructions in the same category, is necessary the overriding of ID method
+  @Override
   public boolean ID() throws IntegerOverflowException, IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
     checkImmediateForOverflow();
     //if the source register is valid passing its own values into a temporary register

--- a/src/main/java/org/edumips64/core/is/DADDI.java
+++ b/src/main/java/org/edumips64/core/is/DADDI.java
@@ -36,12 +36,12 @@ import org.edumips64.core.IrregularStringOfBitsException;
  */
 
 class DADDI extends ALU_IType {
-  private final String OPCODE_VALUE = "011000";
   DADDI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "011000";
     this.name = "DADDI";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException {
     //getting strings from temporary registers
     String imm = TR[IMM_FIELD].getBinString();

--- a/src/main/java/org/edumips64/core/is/DADDIU.java
+++ b/src/main/java/org/edumips64/core/is/DADDIU.java
@@ -40,12 +40,12 @@ import org.edumips64.core.IrregularWriteOperationException;
  */
 
 class DADDIU extends ALU_IType {
-  private final String OPCODE_VALUE = "011001";
   DADDIU() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "011001";
     this.name = "DADDIU";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     long imm = TR[IMM_FIELD].getValue();

--- a/src/main/java/org/edumips64/core/is/LUI.java
+++ b/src/main/java/org/edumips64/core/is/LUI.java
@@ -39,22 +39,14 @@ import org.edumips64.core.fpu.FPInvalidOperationException;
   * @author Trubia Massimo, Russo Daniele
  */
 class LUI extends ALU_IType {
-  private final static int RT_FIELD = 0;
-  private final static int IMM_FIELD = 1;
-  private final static int RT_FIELD_INIT = 11;
-  private final static int RS_FIELD_INIT = 6;
-  private final static int IMM_FIELD_INIT = 16;
-  private final static int RT_FIELD_LENGTH = 5;
-  private final static int RS_FIELD_LENGTH = 5;
-  private final static int IMM_FIELD_LENGTH = 16;
-  private final String OPCODE_VALUE = "001111";
-
   LUI() {
     syntax = "%R,%I";
-    //super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001111";
+    ALU_IType.IMM_FIELD = 1;
     this.name = "LUI";
   }
 
+  @Override
   public boolean ID() throws IntegerOverflowException, IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
     checkImmediateForOverflow();
     //if the source register is valid passing its own values into a temporary register
@@ -65,17 +57,21 @@ class LUI extends ALU_IType {
     TR[IMM_FIELD].writeHalf(params.get(IMM_FIELD));
     return false;
   }
+
+  @Override
   public void EX() throws IrregularStringOfBitsException, IrregularWriteOperationException {
     //getting strings from temporary registers
     String imm = TR[IMM_FIELD].getBinString().substring(16, 64);
-    String imm_shift = imm + "0000000000000000";
-    long imm_shift_lng = Converter.binToLong(imm_shift, false);
-    TR[RT_FIELD].writeDoubleWord(imm_shift_lng);
+    String shift = imm + "0000000000000000";
+    long shiftLong = Converter.binToLong(shift, false);
+    TR[RT_FIELD].writeDoubleWord(shiftLong);
 
     if (cpu.isEnableForwarding()) {
       doWB();
     }
   }
+
+  @Override
   public void pack() throws IrregularStringOfBitsException {
     repr.setBits(OPCODE_VALUE, 0);
     repr.setBits(Converter.intToBin(RS_FIELD_LENGTH, 0), RS_FIELD_INIT);

--- a/src/main/java/org/edumips64/core/is/ORI.java
+++ b/src/main/java/org/edumips64/core/is/ORI.java
@@ -39,13 +39,14 @@ import org.edumips64.core.fpu.FPInvalidOperationException;
  */
 
 class ORI extends ALU_IType {
-  private final String OPCODE_VALUE = "001101";
   ORI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001101";
     this.name = "ORI";
   }
+
   //since this operation is carried out with zero padding of immediate, against sign_extend(immediate) methodology
   //of all others instructions in the same category, is necessary the overriding of ID method
+  @Override
   public boolean ID() throws IntegerOverflowException, IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
     checkImmediateForOverflow();
     //if the source register is valid passing its own values into a temporary register
@@ -62,7 +63,7 @@ class ORI extends ALU_IType {
     //writing the immediate value of "params" on a temporary register
     TR[IMM_FIELD].writeHalf(params.get(IMM_FIELD));
     //forcing zero-padding in the same temporary register
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     for (int i = 0; i < 48; i++) {
       sb.append('0');
@@ -72,12 +73,16 @@ class ORI extends ALU_IType {
     TR[IMM_FIELD].setBits(sb.substring(0), 0);
     return false;
   }
+
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     String imm = TR[IMM_FIELD].getBinString();
     String rs = TR[RS_FIELD].getBinString();
-    StringBuffer sb = new StringBuffer();
-    boolean immbit, rsbit, resbit;
+    StringBuilder sb = new StringBuilder();
+    boolean immbit;
+    boolean rsbit;
+    boolean resbit;
 
     //performing bitwise OR between immediate and rs register
     for (int i = 0; i < 64; i++) {

--- a/src/main/java/org/edumips64/core/is/SLTI.java
+++ b/src/main/java/org/edumips64/core/is/SLTI.java
@@ -37,12 +37,12 @@ import org.edumips64.core.IrregularWriteOperationException;
  */
 
 class SLTI extends ALU_IType {
-  private final String OPCODE_VALUE = "001010";
   SLTI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001010";
     this.name = "SLTI";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     long imm = TR[IMM_FIELD].getValue();

--- a/src/main/java/org/edumips64/core/is/SLTIU.java
+++ b/src/main/java/org/edumips64/core/is/SLTIU.java
@@ -40,17 +40,20 @@ import org.edumips64.core.IrregularWriteOperationException;
  */
 
 class SLTIU extends ALU_IType {
-  private final String OPCODE_VALUE = "001011";
   SLTIU() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001011";
     this.name = "SLTIU";
   }
 
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     String imm = TR[IMM_FIELD].getBinString();
     String rs = TR[RS_FIELD].getBinString();
-    boolean rsbit, rtbit, diff, slt = false;
+    boolean rsbit;
+    boolean rtbit;
+    boolean diff;
+    boolean slt = false;
 
     //comparison between registers as unsigned integers
     for (int i = 0; i < 64; i++) {

--- a/src/main/java/org/edumips64/core/is/XORI.java
+++ b/src/main/java/org/edumips64/core/is/XORI.java
@@ -40,14 +40,14 @@ import org.edumips64.core.fpu.FPInvalidOperationException;
  */
 
 class XORI extends ALU_IType {
-  private final String OPCODE_VALUE = "001110";
   XORI() {
-    super.OPCODE_VALUE = OPCODE_VALUE;
+    super.OPCODE_VALUE = "001110";
     this.name = "XORI";
   }
 
   //since this operation is carried out with zero padding of the immediate, //against sign_extend(immediate) methodology
   //of all others instructions in the same category, it is necessary the overriding of the ID method
+  @Override
   public boolean ID() throws IntegerOverflowException, IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
     checkImmediateForOverflow();
     //if the source register is valid passing its own values into a temporary register
@@ -64,7 +64,7 @@ class XORI extends ALU_IType {
     //writing the immediate value of "params" on a temporary register
     TR[IMM_FIELD].writeHalf(params.get(IMM_FIELD));
     //forcing zero-padding in the same temporary register
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     for (int i = 0; i < 48; i++) {
       sb.append('0');
@@ -74,12 +74,16 @@ class XORI extends ALU_IType {
     TR[IMM_FIELD].setBits(sb.substring(0), 0);
     return false;
   }
+
+  @Override
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException, IrregularWriteOperationException {
     //getting values from temporary registers
     String imm = TR[IMM_FIELD].getBinString();
     String rs = TR[RS_FIELD].getBinString();
-    boolean rsbit, immbit, result;
-    StringBuffer sb = new StringBuffer();
+    boolean rsbit;
+    boolean immbit;
+    boolean result;
+    StringBuilder sb = new StringBuilder();
 
     for (int i = 0; i < 64; i++) {
       //XORI


### PR DESCRIPTION
The fix for issue 475 is to explicitly override `ALU_IType.IMM_FIELD` in `LUI` to the value of `1`.