### PR TITLE
fix: don't change static field in ALU_IType

### DIFF
--- a/src/main/java/org/edumips64/core/is/ALU_IType.java
+++ b/src/main/java/org/edumips64/core/is/ALU_IType.java
@@ -49,7 +49,8 @@ public abstract class ALU_IType extends ComputationalInstructions {
   protected String OPCODE_VALUE = "";
 
   // Needs to be mutable because LUI's syntax is %R,%I, and IMM_FIELD will be 1 in that case.
-  protected static int IMM_FIELD = 2;
+  // Not static because the change pertains to LUI itself, not all ALU I-Type instructions.
+  protected int IMM_FIELD = 2;
 
   private static final Logger logger = Logger.getLogger(ALU_IType.class.getName());
 

--- a/src/main/java/org/edumips64/core/is/LUI.java
+++ b/src/main/java/org/edumips64/core/is/LUI.java
@@ -42,7 +42,7 @@ class LUI extends ALU_IType {
   LUI() {
     syntax = "%R,%I";
     super.OPCODE_VALUE = "001111";
-    ALU_IType.IMM_FIELD = 1;
+    IMM_FIELD = 1;
     this.name = "LUI";
   }
 


### PR DESCRIPTION
When LUI changes ALU_IType.IMM_FIELD, it changes it for all I-Type ALU
instructions, which makes them misbehave horribly and subtly.

This fix makes IMM_FIELD non-static, therefore making it safe for LUI to
change it.

The change was tested by testing jr-raw.s before and after running
some code with the LUI instruction.

Before the fix, jr-raw would go into a loop when ran after the code with
LUI.

After the fix, jr-raw always behaves correctly.

Unit tests for LUI are coming in #488.