### PR TITLE
fix: do not use HTML5 in help

### DIFF
--- a/docs/user/common_conf.py
+++ b/docs/user/common_conf.py
@@ -28,6 +28,10 @@ pygments_style = 'sphinx'
 html_theme = 'epub'
 html_static_path = ['_static']
 htmlhelp_basename = 'EduMIPS64doc'
+html_context = {
+    'html5_doctype': False,
+    'use_meta_charset': False,
+}
 latex_preamble = u'''
 \DeclareUnicodeCharacter{22C3}{$\cup$}
 \DeclareUnicodeCharacter{2208}{$\in$}


### PR DESCRIPTION
The JavaHelp HTML viewer is pretty old and doesn't seem to digest well
specifying the charset only with the <meta charset=".." />
tag/attribute.

This change makes Sphinx output HTML that specifies the charset in a
different way that seems to work well across all platforms.

HTML diff for one file:

```
(docs-1.2.8) 14:34 edumips64 (fix/docs)$ diff build/docs/en/html/fpu.html build-1.2.8-554f52e/docs/en/html/fpu.html 
5,7c5
<     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
<     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
<     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
---
>     <meta charset="utf-8" />
11,15c9,13
<     <script id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
<     <script src="_static/jquery.js"></script>
<     <script src="_static/underscore.js"></script>
<     <script src="_static/doctools.js"></script>
<     <script src="_static/language_data.js"></script> 
---
>     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
>     <script type="text/javascript" src="_static/jquery.js"></script>
>     <script type="text/javascript" src="_static/underscore.js"></script>
>     <script type="text/javascript" src="_static/doctools.js"></script>
>     <script type="text/javascript" src="_static/language_data.js"></script> 
451d448
<             <div class="clearer"></div>
```

Fixes #489.