### PR TITLE
Chore: find and replace project name in URLs

### DIFF
--- a/docs/user/en/src/index.rst
+++ b/docs/user/en/src/index.rst
@@ -14,7 +14,7 @@ status of registers and memory and much more. It is both a simulator and a
 visual debugger.
 
 The website for the project is http://www.edumips.org, and the code is hosted
-at http://github.com/lupino3/edumips64. If you find any bugs, or have any
+at http://github.com/EduMIPS64/edumips64. If you find any bugs, or have any
 suggestion for improving the simulator, please open an issue on github or send
 an email at bugs@edumips.org.
 

--- a/docs/user/it/src/index.rst
+++ b/docs/user/it/src/index.rst
@@ -13,7 +13,7 @@ stalli siano gestiti dalla CPU, lo stato di registri e memoria e molto altro.
 È classificabile sia come simulatore, sia come debugger visuale.
 
 Il sito web del progetto è http://www.edumips.org, ed il codice sorgente è
-disponibile presso http://github.com/lupino3/edumips64. Per segnalare bug o
+disponibile presso http://github.com/EduMIPS64/edumips64. Per segnalare bug o
 inviare suggerimenti sul simulatore, è possibile aprire una issue su github o
 inviare una mail a bugs@edumips.org.
 

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
 # EduMIPS64
 
-![Java CI](https://github.com/lupino3/edumips64/workflows/Java%20CI/badge.svg)
+![Java CI](https://github.com/EduMIPS64/edumips64/workflows/Java%20CI/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/edumips64/badge/?version=latest)](http://edumips64.readthedocs.io/en/latest/?badge=latest)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1511/badge)](https://bestpractices.coreinfrastructure.org/projects/1511)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fdbdfcebfdff4f39a4c6249b49c5a947)](https://www.codacy.com/manual/andrea-spadaccini/edumips64?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=lupino3/edumips64&amp;utm_campaign=Badge_Grade)
-[![codecov](https://codecov.io/gh/lupino3/edumips64/branch/master/graph/badge.svg)](https://codecov.io/gh/lupino3/edumips64)
+[![codecov](https://codecov.io/gh/EduMIPS64/edumips64/branch/master/graph/badge.svg)](https://codecov.io/gh/EduMIPS64/edumips64)
 
 [![Join the chat at https://gitter.im/lupino3/edumips64](https://badges.gitter.im/lupino3/edumips64.svg)](https://gitter.im/lupino3/edumips64?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/edumips64)](https://stackoverflow.com/questions/tagged/edumips64)
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/EduMIPS64/edumips64) 
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/EduMIPS64/edumips64)
 
 EduMIPS64 is a free cross-platform visual MIPS64 CPU simulator written in Java.
 
@@ -18,7 +18,7 @@ EduMIPS64 is a free cross-platform visual MIPS64 CPU simulator written in Java.
 developers' blog at http://edumips64.blogspot.com.
 
 💾 To download the current stable release, go to the [GitHub page for the latest
-release](https://github.com/lupino3/edumips64/releases/latest), which contains
+release](https://github.com/EduMIPS64/edumips64/releases/latest), which contains
 JARs, PDFs with the user documentation and zip/tar.gz files with the source
 code.
 

--- a/src/main/java/org/edumips64/utils/CurrentLocale.java
+++ b/src/main/java/org/edumips64/utils/CurrentLocale.java
@@ -218,7 +218,7 @@ public class CurrentLocale {
     en.put("ErrorDialog.MSG0", "Code contains");
     en.put("ErrorDialog.MSG1", "errors and");
     en.put("ErrorDialog.MSG2", String.valueOf(ConfigKey.WARNINGS));
-    en.put("ReportDialog.MSG", "EduMIPS64 Fatal error!<br/>Please help the developers, by opening a <a href='https://github.com/lupino3/edumips64/issues/new'>new issue on GitHub</a> with the following text, "
+    en.put("ReportDialog.MSG", "EduMIPS64 Fatal error!<br/>Please help the developers, by opening a <a href='https://github.com/EduMIPS64/edumips64/issues/new'>new issue on GitHub</a> with the following text, "
     		+ "or by sending it via email to <a href='mailto:bugs@edumips.org'>bugs@edumips.org</a>.");
     en.put("ReportDialog.BUTTON", "Close");
     en.put("DIVZERO.Message", "Division by zero");
@@ -453,7 +453,7 @@ public class CurrentLocale {
     it.put("ErrorDialog.MSG0", "Il codice contiene");
     it.put("ErrorDialog.MSG1", "errori e");
     it.put("ErrorDialog.MSG2", "avvisi");
-    it.put("ReportDialog.MSG", "Errore fatale!<br/>Aiuta gli sviluppatori, aprendo una <a href='https://github.com/lupino3/edumips64/issues/new'>issue su GitHub</a> con il seguente testo, "
+    it.put("ReportDialog.MSG", "Errore fatale!<br/>Aiuta gli sviluppatori, aprendo una <a href='https://github.com/EduMIPS64/edumips64/issues/new'>issue su GitHub</a> con il seguente testo, "
     		+ "o inviandolo via email a <a href='mailto:bugs@edumips.org'>bugs@edumips.org</a>.");
     it.put("ReportDialog.BUTTON", "Chiudi");
     it.put("DIVZERO.Message", "Divisione per zero");

--- a/src/test/resources/hailstoneenglish.s
+++ b/src/test/resources/hailstoneenglish.s
@@ -1,7 +1,7 @@
     ; An EduMIPS64 test program kindly donated by Gerardo Puga in Issue #132.
-    ; https://github.com/lupino3/edumips64/issues/132
+    ; https://github.com/EduMIPS64/edumips64/issues/132
     ; Adapted by Andrea Spadaccini by removing all compilation warnings.
-    
+
 	; ARQUITECTURA DE COMPUTADORES II, 2014
 	; TP 02: Segmented Architectures
 	;
@@ -22,14 +22,14 @@ result: .word32 0
 	; ---
 
 	.text
-	
+
 	; Initialize the main loop index
 	daddi R5,R0,1
 
 	; Load the start address of the results table on R4
 	daddi R4,R0,result
 
-numloop: 
+numloop:
         ; Initialize R2 with the first number of the sequence
 	dadd R2,R0,R5
 
@@ -39,14 +39,14 @@ numloop:
 	; -----------------
 
 	; Start of the loop that calculates the Hailstone sequence
-hailloop: 
+hailloop:
 
 	; Is the current number even or odd?
 	andi R1,R2,1
 	bne  R1,r0,odd   ; if odd, then go to "odd"
 
 	; -----------------
-	
+
 	; Even numbers
 even:
 	; Divide by two
@@ -66,7 +66,7 @@ odd:
 
 	; -----------------
 anynumber:
-	
+
 	; If the new number is higher than the maximum, this is the new maximum
 	dsub R1,R3,R2      ; Calculate the difference between the current sequence number and the max, put it in R1
 	dsrl R1,R1,31      ; Remove all bits, but the one that contains the sign of the result
@@ -83,7 +83,7 @@ skipnewmax:
 	sw R3,0(R4)
 
 	; Increment the table index
-	daddi R4,R4,4 
+	daddi R4,R4,4
 
 	; Increment the current main loop index
 	daddi R5,R5,1

--- a/src/webapp/data/SampleProgram.js
+++ b/src/webapp/data/SampleProgram.js
@@ -1,6 +1,6 @@
 // Sample MIPS64 program to display.
 const SampleProgram = `; An EduMIPS64 test program kindly donated by Gerardo Puga in Issue #132.
-; https://github.com/lupino3/edumips64/issues/132
+; https://github.com/EduMIPS64/edumips64/issues/132
 ; Adapted by Andrea Spadaccini by removing all compilation warnings.
 ;
 ; Will run for 9765 CPU cycles.
@@ -25,14 +25,14 @@ result: .word32 0
 	; ---
 
 	.text
-	
+
 	; Initialize the main loop index
 	daddi R5,R0,1
 
 	; Load the start address of the results table on R4
 	daddi R4,R0,result
 
-numloop: 
+numloop:
         ; Initialize R2 with the first number of the sequence
 	dadd R2,R0,R5
 
@@ -42,14 +42,14 @@ numloop:
 	; -----------------
 
 	; Start of the loop that calculates the Hailstone sequence
-hailloop: 
+hailloop:
 
 	; Is the current number even or odd?
 	andi R1,R2,1
 	bne  R1,r0,odd   ; if odd, then go to "odd"
 
 	; -----------------
-	
+
 	; Even numbers
 even:
 	; Divide by two
@@ -69,7 +69,7 @@ odd:
 
 	; -----------------
 anynumber:
-	
+
 	; If the new number is higher than the maximum, this is the new maximum
 	dsub R1,R3,R2      ; Calculate the difference between the current sequence number and the max, put it in R1
 	dsrl R1,R1,31      ; Remove all bits, but the one that contains the sign of the result
@@ -86,7 +86,7 @@ skipnewmax:
 	sw R3,0(R4)
 
 	; Increment the table index
-	daddi R4,R4,4 
+	daddi R4,R4,4
 
 	; Increment the current main loop index
 	daddi R5,R5,1
@@ -94,7 +94,7 @@ skipnewmax:
 	; check if we have already covered the first 30 natural numbers
 	daddi R1,R5,-30
     bne R1,r0,numloop
-    
+
     syscall 0
 `;
 

--- a/utils/list-mentioned-issues-since-last-release.sh
+++ b/utils/list-mentioned-issues-since-last-release.sh
@@ -7,5 +7,5 @@ echo "All issues since ${LAST_TAG}"
 
 ISSUES=$(git log HEAD...${LAST_TAG} | egrep "#[0-9]{1,3}" -o | sed -e "s/#//" | sort -n | uniq)
 for issue in $ISSUES; do
-  curl https://api.github.com/repos/lupino3/edumips64/issues/${issue} 2>/dev/null | jq '[.number, .title, .state] | map(tostring) | join(" - ")' | sed 's/"//g'
+  curl https://api.github.com/repos/EduMIPS64/edumips64/issues/${issue} 2>/dev/null | jq '[.number, .title, .state] | map(tostring) | join(" - ")' | sed 's/"//g'
 done

--- a/utils/submit-coverity.sh
+++ b/utils/submit-coverity.sh
@@ -34,13 +34,13 @@ out "Done. Tarball stats:"
 ls -lh ${TARBALL}
 
 out "Uploading tarball to Coverity"
-curl --form project=lupino3%2Fedumips64 \
+curl --form project=EduMIPS64%2Fedumips64 \
      --form token=${TOKEN} \
      --form email=andrea.spadaccini@gmail.com \
      --form file=@${TARBALL} \
      --form version="${VERSION}" \
      --form description="${DESCRIPTION}" \
-     https://scan.coverity.com/builds?project=lupino3%2Fedumips64
+     https://scan.coverity.com/builds?project=EduMIPS64%2Fedumips64
 
 out "Cleaning up.."
 rm -rf ${COVERITY_DIR}

--- a/utils/update-gh-pages.sh
+++ b/utils/update-gh-pages.sh
@@ -31,7 +31,7 @@ GH_PAGES_DIR=${HOME}/gh-pages
 echo -n "Cloning gh-pages branch to ${GH_PAGES_DIR}.. "
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis"
-git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/lupino3/edumips64.git ${GH_PAGES_DIR} > /dev/null
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/EduMIPS64/edumips64.git ${GH_PAGES_DIR} > /dev/null
 echo "done."
 
 echo "Git branch: $TRAVIS_BRANCH"


### PR DESCRIPTION
I noticed the manual was still referencing the old URL so I did a find and replace all over the project (except in a couple of places where it doesn't make sense, e.g. gitter chat).