### PR TITLE
fix: run deploy-ui on all PRs

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'src/main/java/org/edumips64/client/**'
-      - 'src/webapp/**'
-      - '.babelrc'
-      - 'package.json'
-      - 'package.json.lock'
-      - 'webpack.config.js'
 
 jobs:
   deploy-ui:


### PR DESCRIPTION
Has to be done, because it's now a required check, and I found no way to bypass it.