### PR TITLE
fix: do not load Java preferences during tests

### DIFF
--- a/src/test/java/org/edumips64/CliRunnerTest.java
+++ b/src/test/java/org/edumips64/CliRunnerTest.java
@@ -2,7 +2,7 @@ package org.edumips64;
 
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.CurrentLocale;
-import org.edumips64.utils.JavaPrefsConfigStore;
+import org.edumips64.utils.InMemoryConfigStore;
 import org.edumips64.utils.cli.Cli;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,14 +18,12 @@ import static org.junit.Assert.*;
 
 public class CliRunnerTest {
     private Cli cli;
-    private ConfigStore cfg;
 
     @Before
     public void setUp() {
-        cfg = new JavaPrefsConfigStore(ConfigStore.defaults);
+        var cfg = new InMemoryConfigStore(ConfigStore.defaults);
         CurrentLocale.setConfig(cfg);
         cli = new Cli(cfg);
-        Locale.setDefault(Locale.ENGLISH);
     }
 
     @Test


### PR DESCRIPTION
Use in-memory preferences engine instead of the one based on Java
preferences during unit tests. This ensures hermetic execution and
prevents bugs caused by mismatched text in languages other than English.

Fixes #499 