### PR TITLE
chore(deps): migrate to setup-java v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,10 @@ jobs:
       #   languages: go, javascript, csharp, python, cpp, java
     
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v2
       with:
         java-version: 11 
+        distribution: 'adopt'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'adopt'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build Web UI

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'adopt'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Install docs dependencies
@@ -73,9 +74,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'adopt'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build Web UI

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
-        distribution: 'adopt'
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
+        distribution: 'adopt'
         with:
           java-version: 11
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
Renovate couldn't do it because it's a breaking change that requires a
new option.