### PR TITLE
feat: adopt Gradle task for Python

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,8 @@
  * EduMIPS64 Gradle build configuration
  */
 import java.time.LocalDateTime
-import org.gradle.internal.os.OperatingSystem
+import ru.vyarus.gradle.plugin.python.task.PythonTask
+import ru.vyarus.gradle.plugin.python.PythonExtension.Scope.VIRTUALENV
 
 plugins {
     java
@@ -13,6 +14,7 @@ plugins {
     id ("jacoco")
     id ("com.dorongold.task-tree") version "1.5"
     id ("us.ascendtech.gwt.classic") version "0.5.1"
+    id ("ru.vyarus.use-python") version "2.3.0"
 }
 
 repositories {
@@ -30,6 +32,12 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
 }
 
+python {
+    pip("sphinx:3.5.4")
+    pip("rst2pdf:0.98")
+    scope = VIRTUALENV
+}
+
 application {
   mainClassName = "org.edumips64.Main"  
 }
@@ -45,35 +53,31 @@ tasks.compileJava {
 /* 
  * Documentation tasks. To avoid dependency on GNU Make, these tasks duplicate the commands run by the Sphinx makefiles.
  */
-fun buildDocsCmd(language: String, type: String) : List<String> {
+fun buildDocsCmd(language: String, type: String) : String {
     val baseDir = "${buildDir}/docs/${language}"
-    val pythonCmd = when (OperatingSystem.current()) {
-        OperatingSystem.WINDOWS -> "py -3"
-        else -> "python3"
-    }
-    val cmd = "${pythonCmd} -m sphinx -N -a -E . ${baseDir}/${type} -b ${type} -d ${baseDir}/doctrees"
-    return cmd.split(" ")
+    return "-m sphinx -N -a -E . ${baseDir}/${type} -b ${type} -d ${baseDir}/doctrees"
 }
 
-tasks.create<Exec>("htmlDocsEn"){
-    workingDir = File("${projectDir}/docs/user/en/src")
-    commandLine(buildDocsCmd("en", "html"))
+tasks.register<PythonTask>("htmlDocsEn") {
+    workDir = "${projectDir}/docs/user/en/src"
+    command = buildDocsCmd("en", "html")
 }
 
-tasks.create<Exec>("htmlDocsIt") {
-    workingDir = File("${projectDir}/docs/user/it/src")
-    commandLine(buildDocsCmd("it", "html"))
+tasks.register<PythonTask>("htmlDocsIt") {
+    workDir = "${projectDir}/docs/user/en/src"
+    command = buildDocsCmd("it", "html")
 }
 
-tasks.create<Exec>("pdfDocsEn") {
-    workingDir = File("${projectDir}/docs/user/en/src")
-    commandLine(buildDocsCmd("en", "pdf"))
+tasks.register<PythonTask>("pdfDocsEn") {
+    workDir = "${projectDir}/docs/user/en/src"
+    command = buildDocsCmd("en", "pdf")
 }
 
-tasks.create<Exec>("pdfDocsIt") {
-    workingDir = File("${projectDir}/docs/user/it/src")
-    commandLine(buildDocsCmd("it", "pdf"))
+tasks.register<PythonTask>("pdfDocsIt") {
+    workDir = "${projectDir}/docs/user/it/src"
+    command = buildDocsCmd("it", "pdf")
 }
+
 
 // Catch-all task for documentation
 tasks.create<GradleBuild>("allDocs") {

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -20,23 +20,16 @@
 
 In order to compile EduMIPS64, you need the Java JDK version 11 or above.
 
-To build the user documentation, you'll need:
-
-- Python 3
-- Sphinx (http://www.sphinx-doc.org/) version 2.3.1 or above
-- rst2pdf (for the PDF files) version 0.9.6 or above
-
-You can install the Python dependencies using PIP:
-
-```
-$ pip3 install -r docs/requirements.txt
-```
+To build the user documentation, you'll need Python 3 with pip.
 
 [Gradle](https://gradle.org/) will download the following dependencies:
 
 - JUnit
 - JavaHelp
 - GWT (experimental)
+- Python dependencies to build the documentation (they'll be installed in a virtual environment)
+  - Sphinx (http://www.sphinx-doc.org/) version 3.4.3 or above
+  - rst2pdf (for the PDF files) version 0.98 or above
 
 To generate an installable Windows MSI package (using the Gradle `msi` task), you will need 
 JDK 14+ and the WiX toolkit.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,7 @@
+# NOTE: those dependencies are duplicated in the Gradle build file because the
+# Gradle module for Python does not support reading requirements from an external
+# file, and having an external file makes it possible to use automatic dependency
+# upgrades, with the caveat that the Gradle build file needs to be manually kept
+# in sync with this file.
 sphinx==3.5.4
 rst2pdf==0.98


### PR DESCRIPTION
Adopt ru.vyarus.use-python, that abstracts away installing Python dependencies and running Python scripts across multiple platforms, with the added benefit of allowing the use of a virtual environment to install build-time Python dependencies.