### PR TITLE
tweak: remove pip install from snap build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,6 @@ parts:
     gradle-version: '6.3'
     gradle-options: [jar]
     override-build: |
-      pip3 install -r docs/requirements.txt -U
       snapcraftctl build
     build-packages:
       - git


### PR DESCRIPTION
It's unnecessary because it's already done by the Gradle build.