### PR TITLE
Do CI/CD on fixed JDK version and use Zulu instead of Adopt or Temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,16 @@ jobs:
   build-desktop:
     name: Build desktop application and docs
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [11, 11.0.3]    
     steps:
       # Set up Java development environment.
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 


### PR DESCRIPTION
Adding fixed JDK 11 version for your CI/CD pipeline so that you have a specific version to do setup-java against. If the pipeline against the latest JDK version fails while it continues to succeed against the fixed version, you'll know that the build failure is related to the latest JDK 11 version and not to an error in your code.

Also, since Adopt is no more, the alternative JDK distros to use are Temurin and Zulu, though Temurin doesn't provide all the JDK versions since it is new, while Zulu has a more complete set of JDKs, useful for using fixed versions, so switched from Adopt to Temurin to Zulu.