### PR TITLE
fix: point snapcraft JAVA_HOME to JRE 17

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -44,6 +44,9 @@ apps:
   edumips64:
     desktop: edumips64.desktop
     command: edumips64-snap-wrapper.sh
+    environment:
+      JAVA_HOME: $SNAP/usr/lib/jvm/java-17-openjdk-amd64
+      PATH: $JAVA_HOME/jre/bin:$PATH
     plugs:
       - home
       - x11


### PR DESCRIPTION
Should fix issues running the snap where JRE 11 is picked, and class files built
with JDK 17 are not compatible with older JREs.