### PR TITLE
release: 1.2.10

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,3 +33,5 @@
 * Miguel Pinto - [**@rocas777**](http://github.com/rocas777)
 * Pimts - [**@pimts**](http://github.com/pimts)
 * iwodder - [**@iwodder**](http://github.com/iwodder)
+* jcarletta - [**jcarletta**](http://github.com/jcarletta)
+* hugmanrique - [**hugmanrique**](http://github.com/hugmanrique)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Parser incorrectly interprets hexadecimal immediates (Issue #450)
 - Some floating-point division cycles missing in Cycles window (Issue #646)
+- Infinite RAW stall in floating-point code (Issue #304) (yes, *again*)
 
 ### Changed
 - Migrated to JDK (and JRE) 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # EduMIPS64 ChangeLog
 
-## 1.2.10 (2022) - ?
+## 1.2.10 (03/2022) - FP - Freedom and Peace
+
+### Added
+- New Snapcraft packages for armhf (e.g. Raspberry PI) and other architectures
+
 ### Fixed
+- Parser incorrectly interprets hexadecimal immediates (Issue #450)
 - Some floating-point division cycles missing in Cycles window (Issue #646)
+
+### Changed
+- Migrated to JDK (and JRE) 17
 
 ## 1.2.9 (08/11/2020) - Baby Shark
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # EduMIPS64 ChangeLog
 
-## 1.2.10 (03/2022) - FP - Freedom and Peace
+## 1.2.10 (05/03/2022) - FP - Freedom and Peace
 
 ### Added
 - New Snapcraft packages for armhf (e.g. Raspberry PI) and other architectures

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,24 @@
 # EduMIPS64 version 1.2.10
 
-*March, 2021*
+*5th of March, 2021*
 
 EduMIPS64 is a GPL MIPS64 Instruction Set Architecture (ISA) simulator and graphical debugger.
 
 ## Notes for this release
 
-This is version 1.2.10 of EduMIPS64. Its codename is FP - Freedom and Peace, because
+This is version 1.2.10 of EduMIPS64. Its codename is **FP - Freedom and Peace**, because
 of the ongoing conflict in Ukraine, which is being invaded by Russia. Freedom and Peace
 is what I wish right now to the Ukrainians.
 
-TODO: describe version
+This is mostly a bug-fixing release: issues #450, #646 and #304 (for the second time) were
+fixed. In terms of development changes, we moved to JDK (and JRE) 17 and we fixed the Snapcraft
+packages for the `armhf` architecture (among others). The latter means that EduMIPS64 is
+available on Raspberry PI via `snap`!
 
 This version contains contributions from the following people, listed in no particular order:
 
-TODO: add contributors
+* @hugmanrique and @jcarletta - reported 2 critical bugs and provided MIPS64 code to reproduce them,
+  which I was allowed to incorporate as regression tests.
 * Andrea Spadaccini - [**@lupino3**](http://github.com/lupino3)
 
 Please keep in mind that this is still EXPERIMENTAL SOFTWARE. It may
@@ -28,4 +32,17 @@ EduMIPS64 is hosted on GitHub: www.github.com/EduMIPS64/edumips64.
 Our web site is www.edumips.org, and our development blog is http://edumips64.blogspot.com.
 
 ## Main changes since 1.2.9
-TODO: add.
+
+### Added
+
+* New Snapcraft packages for armhf (e.g. Raspberry PI) and other architectures
+
+### Fixed
+
+* Parser incorrectly interprets hexadecimal immediates (Issue #450)
+* Some floating-point division cycles missing in Cycles window (Issue #646)
+* Infinite RAW stall in floating-point code (Issue #304) (yes, *again*)
+
+### Changed
+
+* Migrated to JDK (and JRE) 17

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,23 +1,20 @@
-# EduMIPS64 version 1.2.9
+# EduMIPS64 version 1.2.10
 
-*8th of November, 2020*
+*March, 2021*
 
 EduMIPS64 is a GPL MIPS64 Instruction Set Architecture (ISA) simulator and graphical debugger.
 
 ## Notes for this release
 
-This is version 1.2.9 of EduMIPS64. Its codename is Baby Shark, because my
-brain is overloaded with the song thanks to my son, and for some reason this
-is the only name that comes to mind right now.
+This is version 1.2.10 of EduMIPS64. Its codename is FP - Freedom and Peace, because
+of the ongoing conflict in Ukraine, which is being invaded by Russia. Freedom and Peace
+is what I wish right now to the Ukrainians.
 
-This version contains 2 major bug fixes, one for the LUI instruction, which in 1.2.8 was not
-completely fixed, and another for the in-app manual, which was not displayed correctly
-in some platforms.
+TODO: describe version
 
 This version contains contributions from the following people, listed in no particular order:
 
-* leopoldwe - [**@leopoldwe**](http://github.com/leopoldwe)
-* Paolo Viotti - [**@pviotti**](http://github.com/pviotti)
+TODO: add contributors
 * Andrea Spadaccini - [**@lupino3**](http://github.com/lupino3)
 
 Please keep in mind that this is still EXPERIMENTAL SOFTWARE. It may
@@ -30,10 +27,5 @@ EduMIPS64 is hosted on GitHub: www.github.com/EduMIPS64/edumips64.
 
 Our web site is www.edumips.org, and our development blog is http://edumips64.blogspot.com.
 
-## Main changes since 1.2.8
-### Added
-- Unit tests for multiple instructions (PR 488)
-
-### Fixed
-- LUI modifies static field of `ALU_IType` breaking the simulator every time it is run (Issue #501)
-- Character encoding issues in manual (Issue #489)
+## Main changes since 1.2.9
+TODO: add.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -254,8 +254,9 @@ tasks.create<Exec>("msi"){
         if (!("Windows" in os)){
             throw GradleException("MSI creation must be executed on Windows")
         }
+        var majorVersion = System.getProperty("java.version").split(".")[0].toInt()
         
-        if (System.getProperty("java.version").toInt() < 14) {
+        if (majorVersion < 14) {
             throw GradleException("JDK 14+ is required to create the MSI package.")
         }
         

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -207,3 +207,5 @@ be automated, but before that is done those checks should be done manually.
 - open the English manual and check the version
 - open the Italian manual and check the version
 - check the 'edge' snap and promote it to stable if it works (https://snapcraft.io/edumips64/releases, needs login)
+  - test both on amd64 and armhf (Raspberry PI)
+- update winget manifest on https://github.com/microsoft/winget-pkgs/tree/master/manifests/e/EduMIPS64/EduMIPS64

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -18,7 +18,7 @@
 
 ### Requirements
 
-In order to compile EduMIPS64, you need the Java JDK version 11 or above.
+In order to compile EduMIPS64, you need the Java JDK version 17 or above.
 
 To build the user documentation, you'll need Python 3 with pip.
 
@@ -31,8 +31,7 @@ To build the user documentation, you'll need Python 3 with pip.
   - Sphinx (http://www.sphinx-doc.org/) version 3.4.3 or above
   - rst2pdf (for the PDF files) version 0.98 or above
 
-To generate an installable Windows MSI package (using the Gradle `msi` task), you will need 
-JDK 14+ and the WiX toolkit.
+To generate an installable Windows MSI package (using the Gradle `msi` task), you will need the WiX toolset.
 
 This project uses GitHub Actions for continuous integration
 (https://github.com/EduMIPS64/edumips64/actions).

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -196,16 +196,27 @@ Follow instructions [here](https://dev.cloudburo.net/2018/06/03/install-letsencr
 Before doing a release, please do the following tasks. Over time, those should
 be automated, but before that is done those checks should be done manually.
 
-- For each released JAR / MSI file:
+Before committing the release commit:
+
+- run `./gradlew release`
+- JAR and MSI:
   - verify that the splash screen works
   - verify that the version number, code name, build date and git ID are correct
   - open one .s file (e.g., `div.d.s`)
   - run it
   - open the help
   - close the application
-  - verify the JAR size (should be < 3 MB)
-- open the English manual and check the version
-- open the Italian manual and check the version
-- check the 'edge' snap and promote it to stable if it works (https://snapcraft.io/edumips64/releases, needs login)
-  - test both on amd64 and armhf (Raspberry PI)
-- update winget manifest on https://github.com/microsoft/winget-pkgs/tree/master/manifests/e/EduMIPS64/EduMIPS64
+- JAR-only: verify the JAR size (should be < 3 MB)
+- PDF:
+  - open the English manual and check the version
+  - open the Italian manual and check the version
+
+After committing, check out `master` and run `./gradlew release` again.
+
+Trigger builds on snapcraft.
+
+Create release and update artifacts generated from `master`.
+
+Check the 'edge' snap and promote it to stable if it works (https://snapcraft.io/edumips64/releases, needs login)Test both on amd64 and armhf (Raspberry PI)
+
+Update winget manifest on https://github.com/microsoft/winget-pkgs/tree/master/manifests/e/EduMIPS64/EduMIPS64

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -211,6 +211,7 @@ Before committing the release commit:
   - open the English manual and check the version
   - open the Italian manual and check the version
 
+Make sure the version number on `snapcraft.yaml` is updated.
 After committing, check out `master` and run `./gradlew release` again.
 
 Trigger builds on snapcraft.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.2.9
-codename="Baby Shark"
+version=1.2.10
+codename="FP - Freedom and Peace"

--- a/scripts/edumips64-snap-wrapper.sh
+++ b/scripts/edumips64-snap-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-$SNAP/usr/lib/jvm/java-17-openjdk-$SNAP_ARCH/bin/java -jar -Djava.util.prefs.userRoot="$SNAP_USER_DATA" $SNAP/jar/edumips64-1.2.9.jar $*
+$SNAP/usr/lib/jvm/java-17-openjdk-$SNAP_ARCH/bin/java -jar -Djava.util.prefs.userRoot="$SNAP_USER_DATA" $SNAP/jar/edumips64-1.2.10.jar $*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edumips64
-version: '1.2.9'
+version: '1.2.10'
 summary: A free visual and cross-platform MIPS64 CPU simulator.
 description: EduMIPS64 is a free MIPS64 visual simulator and debugger, used as a teaching tool in Computer Architecture courses.
 grade: stable


### PR DESCRIPTION
Update documentation and version numbers.

Changelog:

### Added
- New Snapcraft packages for armhf (e.g. Raspberry PI) and other architectures

### Fixed
- Parser incorrectly interprets hexadecimal immediates (Issue #450)
- Some floating-point division cycles missing in Cycles window (Issue #646)
- Infinite RAW stall in floating-point code (Issue #304) (yes, *again*)

### Changed
- Migrated to JDK (and JRE) 17