### PR TITLE
fix: remove JDK/JRE 11 from snap and test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,9 @@ jobs:
           command: npm run test
 
   build-snap:
-    name: Build Snapcraft build
+    name: Build Snapcraft package
     runs-on: ubuntu-latest
+    needs: deploy-web
     steps:
       - uses: actions/checkout@v3
       - uses: snapcore/action-build@v1
@@ -218,5 +219,21 @@ jobs:
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+  
+  test-snap:
+    name: Test Snapcraft package
+    runs-on: ubuntu-latest
+    needs: build-snap
+    steps:
+      - uses: actions/download-artifact@v2
+        name: Download snap package
+        with:
+          name: snap
+          path: .
+      - name: Unpack and install snap
+        run: |
+          unsquashfs edumips64*.snap
+          sudo snap try squashfs-root/
+          echo "exit" | edumips64.edumips64-cli
 
     

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,9 +12,12 @@ parts:
     plugin: gradle
     source: https://github.com/edumips64/edumips64.git
     gradle-version: '7.4'
-    gradle-options: [jar]
-    override-build: |
-      snapcraftctl build
+    # Remove Java 11, which is not needed and pulled in by default by the Snapcraft Gradle plugin.
+    # This also fixes the issue with a dangling JDK 11 symlink:
+    # https://forum.snapcraft.io/t/resolve-package-contains-external-symlinks-error-when-trying-to-snap/2963/18
+    override-prime: |
+      snapcraftctl prime
+      rm -rvf usr/lib/jvm/java-11-*
     build-packages:
       - git
       - openjdk-17-jdk       
@@ -33,9 +36,8 @@ parts:
       - libopenjp2-7-dev
       - libraqm-dev
       - libxcb-xfixes0-dev
+
     stage-packages:
-      # This is required because snap ships the headless version by default,
-      # which lacks splashscreen support.
       - openjdk-17-jre
 
   scripts:


### PR DESCRIPTION
This creates a smaller snap (fixes #657) and also removes a dangling
symlink that makes recent snaps fail snapcraft validation (fixes #656).