### PR TITLE
chore: upgrade snap base to core22

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: A free visual and cross-platform MIPS64 CPU simulator.
 description: EduMIPS64 is a free MIPS64 visual simulator and debugger, used as a teaching tool in Computer Architecture courses.
 grade: stable
 
-base: core18
+base: core22
 confinement: strict
 
 parts:


### PR DESCRIPTION
The recent Sphinx upgrade dropped support for older Python versions, and this broke snap builds. This should fix it.