### PR TITLE
chore: use Python3.8 for snap build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 python {
     scope = VIRTUALENV
     requirements.file = "docs/requirements.txt"
+    minPythonVersion = "3.8"
 }
 
 application {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,15 +18,21 @@ parts:
     override-prime: |
       snapcraftctl prime
       rm -rvf usr/lib/jvm/java-11-*
+    # Install Python 3.8 and make it the default Python3 before the build stage,
+    # so that the build can use it and satisfy the Python >= 3.8 dependency from
+    # Sphinx >= 6.
+    override-pull: |
+      snapcraftctl pull
+      apt install -y python3.8
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
     build-packages:
       - git
       - openjdk-17-jdk       
       - ca-certificates-java
       - ca-certificates
-      - python3
       - python3-pip
       # Needed to build pillow, a rst2pdf dependency.
-      - python3-dev
+      - python3.8-dev
       - zlib1g-dev
       - libjpeg-dev
       - libtiff-dev


### PR DESCRIPTION
This is necessary for Sphinx >= 6, and apparently the core18 snap base comes with 3.6. More modern bases don't have the gradle plugin, so this seems to be the quickest fix for the build.