### PR TITLE
Fix deployment URL for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           echo "DEPLOYMENT_ENV=${{github.event.pull_request.number}}" >> $GITHUB_ENV
           echo "PUSH_DIR=pr/" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=Deploy code for PR ${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          echo "DEPLOYMENT_ENV_URL=https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_ENV_URL=https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}/" >> $GITHUB_ENV
       - name: Set master push environment variables
         if: ${{ github.event_name != 'pull_request' }}
         run: |
@@ -255,7 +255,7 @@ jobs:
       - name: Run web tests against deployed code
         uses: nick-fields/retry@v2
         env:
-          PLAYWRIGHT_TARGET_URL: https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}
+          PLAYWRIGHT_TARGET_URL: https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}/
         with:
           max_attempts: 10
           timeout_minutes: 2


### PR DESCRIPTION
The current deployment URL for PRs is incorrect, as it points to the root of the domain and it makes all resources resolve to the latest master.

This PR updates the deployment URL so that it actually points to the right PR directory.