### PR TITLE
fix: build Italian docs for 'it' language

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ tasks.register<PythonTask>("htmlDocsEn") {
 }
 
 tasks.register<PythonTask>("htmlDocsIt") {
-    workDir = "${projectDir}/docs/user/en/src"
+    workDir = "${projectDir}/docs/user/it/src"
     command = buildDocsCmd("it", "html")
 }
 tasks.register<PythonTask>("htmlDocsZh") {


### PR DESCRIPTION
Should fix the bug found while preparing 1.3.0 (see #819)