### PR TITLE
Use recommended renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "extends": [
-    "config:base",
-    "schedule:weekly",
-    "group:allNonMajor"
+    "config:recommended",
   ],
   "stabilityDays": 7
 }


### PR DESCRIPTION
This will add the dependency dashboard at least.

Right now dependency grouping doesn't work well, because we need to keep sphinx back to 7.1.x but we want to update other dependencies. Let's see if there is a more flexible way of achieving this goal.