### PR TITLE
Revert "chore(deps): update dependency eslint to v9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-loader": "9.1.3",
     "copy-webpack-plugin": "12.0.2",
     "css-loader": "7.1.2",
-    "eslint": "^9.0.0",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.29.1",


### PR DESCRIPTION
This reverts commit 8045ea386bf53a10255f5193e6aaf096ecf54f6b.

With required checks, this change should not get into master anymore.