### PR TITLE
fix: update RTD YAML to use root-repo-relative paths

### DIFF
--- a/docs/user/en/src/.readthedocs.yaml
+++ b/docs/user/en/src/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: "conf.py"
+  configuration: "docs/user/en/src/conf.py"
 
 formats:
   - pdf
@@ -18,4 +18,4 @@ formats:
 
 python:
    install:
-   - requirements: "../../../requirements.txt"
+   - requirements: "docs/requirements.txt"

--- a/docs/user/it/src/.readthedocs.yaml
+++ b/docs/user/it/src/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: "conf.py"
+  configuration: "docs/user/it/src/conf.py"
 
 formats:
   - pdf
@@ -18,4 +18,4 @@ formats:
 
 python:
    install:
-   - requirements: "../../../requirements.txt"
+   - requirements: "docs/requirements.txt"

--- a/docs/user/zh/src/.readthedocs.yaml
+++ b/docs/user/zh/src/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: "docs/user/zh/conf.py"
+  configuration: "docs/user/zh/src/conf.py"
 
 formats:
   - pdf

--- a/docs/user/zh/src/.readthedocs.yaml
+++ b/docs/user/zh/src/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: "conf.py"
+  configuration: "docs/user/zh/conf.py"
 
 formats:
   - pdf
@@ -18,4 +18,4 @@ formats:
 
 python:
    install:
-   - requirements: "../../../requirements.txt"
+   - requirements: "docs/requirements.txt"


### PR DESCRIPTION
Paths in .readthedocs.yaml must be relative to the root of the repo.

This PR changes the config file for all projects (one per language) to use root-repo-relative paths for the Sphinx configuration and requirements files.

Fixes #1204 