### PR TITLE
fix(dev): allow actions requiring secrets from safe external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       
       # Fallback for external contributors when deployment API can't be triggered
       - name: Post deployment URL as PR comment
-        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'}}
+        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true' && steps.deployment.outcome != 'success'}}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
       - master
   schedule:
     - cron: '0 0 * * *'
-
+  # The pull_request event, by default, does not allow access to repo secrets by external contributors.
+  # The pull_request_target provides access to secrets, runs the workflow @ base branch (thus preventing from possible changes
+  # to the workflow) and therefore allows safe check for a given label, which can be added by maintainers.
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   build-desktop:
@@ -153,19 +157,23 @@ jobs:
       # This step behaves differently in PRs and on push to master / cron.
       # Set up environment variables according to the triggering event.
       - name: Set PR environment variables
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         run: |
           echo "DEPLOYMENT_ENV=${{github.event.pull_request.number}}" >> $GITHUB_ENV
           echo "PUSH_DIR=pr/" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=Deploy code for PR ${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "DEPLOYMENT_ENV_URL=https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}/" >> $GITHUB_ENV
+          echo "IS_PR=true" >> $GITHUB_ENV
+          echo "IS_PR_SAFE=${{github.event_name == 'pull_request' || contains(github.event.pull_request.labels.*.name, 'safe to test')}}" >> $GITHUB_ENV
+
       - name: Set master push environment variables
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name == 'push' || github.event_name == 'schedule'
         run: |
           echo "DEPLOYMENT_ENV=prod" >> $GITHUB_ENV
           echo "PUSH_DIR=build/gwt/war/edumips64" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=Update Web Frontend @ ${{ github.sha }}" >> $GITHUB_ENV
           echo "DEPLOYMENT_ENV_URL=https://web.edumips.org" >> $GITHUB_ENV
+          echo "IS_PR=false" >> $GITHUB_ENV
 
       # Download web application built in 'build-web'
       - uses: actions/download-artifact@v4.1.9
@@ -174,10 +182,11 @@ jobs:
           name: web
           path: build/gwt/war/edumips64
 
-      # Mark the deployment as started (allows the PR to display "Deployment started" messages.)
+      # Mark the PR deployment as started (allows the PR to display "Deployment started" messages.)
       - name: Start deployment
         uses: bobheadxi/deployments@v1.5.0
         id: deployment
+        if: ${{ env.IS_PR == 'true'}}
         continue-on-error: true
         with:
           step: start
@@ -189,12 +198,12 @@ jobs:
       # Copy files to a directory to allow pushing to a subdir in the web.edumips.org repo.
       - name: Copy files to run directory
         run: mkdir -p pr/${{ github.event.pull_request.number }} && cp -r build/gwt/war/edumips64/* pr/${{ github.event.pull_request.number }}
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'}}
         
       # Upload to Azure blob if this is a PR.
       - name: Login to Azure
         uses: azure/login@v2
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'}}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -202,13 +211,13 @@ jobs:
           
       - name: Upload to Azure blob storage (${{ env.DEPLOYMENT_ENV_URL }})
         uses: azure/CLI@v2
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'}}
         with:
           inlineScript: |
               az storage blob upload-batch --account-name edumips64ci --auth-mode key -d '$web/${{ github.event.pull_request.number }}' -s pr/${{ github.event.pull_request.number }} --overwrite
       
       - name: Deploy master web application to web.edumips.org
-        if: ${{ success() && github.event_name != 'pull_request' }}
+        if: ${{ success() && env.IS_PR == 'false'}}
         uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: master
@@ -220,10 +229,10 @@ jobs:
         env:
           GH_PAT: ${{ secrets.PAT_WEBUI }}
 
-      # Mark the deployment as succeeded or failed.
+      # Mark the PR deployment as succeeded or failed.
       - name: Update deployment status
         uses: bobheadxi/deployments@v1.5.0
-        if: always() && github.head_ref && steps.deployment.outcome == 'success'
+        if: always() && github.head_ref && steps.deployment.outcome == 'success' && env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -234,7 +243,7 @@ jobs:
       
       # Fallback for external contributors when deployment API can't be triggered
       - name: Post deployment URL as PR comment
-        if: github.event_name == 'pull_request' && (steps.deployment.outcome == 'failure' || steps.deployment.outputs.deployment_id == '')
+        if: ${{ env.IS_PR == 'true' && env.IS_PR_SAFE == 'true'}}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -260,7 +269,7 @@ jobs:
     name: Test web application
     runs-on: ubuntu-latest
     needs: deploy-web
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target'}}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.JS


### PR DESCRIPTION
By default, secrets are not available from workflows triggered
by external PRs, which go through the pull_request event.

This PR adds a way to execute workflows for those PRs via
the (more dangerous) event pull_request_target, which runs
in the context of the base branch and provides secrets, and
in this case is triggered by the "safe to test" label, which can
only be set by maintainers.

Fixes #1281.