### PR TITLE
fix: switch to pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
   push:
@@ -21,6 +21,9 @@ jobs:
     steps:
       # Set up Java development environment.
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -149,7 +152,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     needs: build-web
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request_target' }}
     environment:
       name: Staging
       url: https://edumips64ci.z16.web.core.windows.net/${{github.event.pull_request.number}}/
@@ -185,7 +188,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     needs: build-web
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     steps:
       # Download web application built in 'build-web'
       - uses: actions/download-artifact@v4.2.1


### PR DESCRIPTION
This should have access to environment secrets even from external forks.

It should be safe because the environment is protected by a manual approval step.