### PR TITLE
Remove default expansion from StdOut's Accordion

### DIFF
--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -325,7 +325,7 @@ const Simulator = ({ sim, initialState, appInsights }) => {
                 <Memory memory={memory} />
               </AccordionDetails>
             </Accordion>
-            <Accordion defaultExpanded disableGutters>
+            <Accordion disableGutters>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography variant="h6" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
                   Standard Output


### PR DESCRIPTION
StdOut section should be expanded only when inspected by user, coherently with Registers, Pipeline, Memory.
Also, many programs just don't produce any stdout and keeping it expanded with a blank box consumes a lot of space on the right side, making settings tab not visible in many resolutions. Hopefully, Settings tab will be filled with more controls that user wants to access easily.