### PR TITLE
Fix bit width in `getValueHex` method.

### DIFF
--- a/src/main/java/org/edumips64/core/MemoryElement.java
+++ b/src/main/java/org/edumips64/core/MemoryElement.java
@@ -117,7 +117,7 @@ public class MemoryElement extends BitSet64 {
   }
   public String getValueHex() {
     try {
-      return Converter.binToHex(Converter.positiveIntToBin(32, this.getValue()));
+      return Converter.binToHex(Converter.positiveIntToBin(64, this.getValue()));
     } catch (IrregularStringOfBitsException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
For some reason, probably as legacy of the old 32/64 bit lenght distinction for memory section code/data, WebUI memory is initialized using hex values computed using `positiveIntToBin` on 32 bits.
The resulting effect is shown in the first pic, with the second column of different sizes.
This could be acceptable for the first column, like "ok addresses are 64 bits but they are a read-only field and we gain interface space since we will never need so distant memory regions."
But for the second column generate confusing effects, as shown in the second pic where storing the byte "6" on location 50 casuses the line to be filled with 0's, but only on the right.
This PR put a 64 bit length for hex value since the beginning to avoid this weird behaviours (see last pic),

**Memory with weird lengths:**
<img width="416" alt="mem_32bit" src="https://github.com/user-attachments/assets/a295a301-6580-4fb9-ba97-a99b5974eb27" />
**before storing the byte:**
![store_byte_pre](https://github.com/user-attachments/assets/90d9ea4d-4092-4a32-802e-cdefc0e3b0c6)
**after storing the byte:**
![store_byte](https://github.com/user-attachments/assets/a22d742e-d1de-4794-8b2b-0cdaeb1cabd6)
**behaviour with this PR:**
![64_store_byte](https://github.com/user-attachments/assets/4d37ee42-e388-4f7a-ab51-461373e3e96b)

