### PR TITLE
WebUI Syntax Coloring

### DIFF
--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -4,7 +4,7 @@ import { initVimMode } from 'monaco-vim';
 // new
 import MonacoEditor from 'react-monaco-editor';
 import useMediaQuery from '@mui/material/useMediaQuery';
-// Definizione globale del linguaggio MIPS per Monaco
+// Global MIPS language definition for the Monaco editor.
 import * as monaco from 'monaco-editor';
 
 monaco.languages.register({ id: 'mips' });

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -4,6 +4,23 @@ import { initVimMode } from 'monaco-vim';
 // new
 import MonacoEditor from 'react-monaco-editor';
 import useMediaQuery from '@mui/material/useMediaQuery';
+// Definizione globale del linguaggio MIPS per Monaco
+import * as monaco from 'monaco-editor';
+
+monaco.languages.register({ id: 'mips' });
+
+monaco.languages.setMonarchTokensProvider('mips', {
+  tokenizer: {
+    root: [
+      [/\b(?:add|addi|dadd|daddi|sub|mul|div|and|or|nor|sll|srl|lw|sw|ld|sd|li|move|syscall)\b/, 'keyword'],
+      [/[#,]/, 'delimiter'],
+      [/\$[a-z0-9]+/, 'variable'],
+      [/\d+/, 'number'],
+      [/".*?"/, 'string'],
+      [/[a-zA-Z_][\w]*/, 'identifier'],
+    ]
+  }
+});
 
 const Code = (props) => {
 

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -13,13 +13,13 @@ monaco.languages.setMonarchTokensProvider('mips', {
   tokenizer: {
     root: [
       [/^[ \t]*[a-zA-Z_][\w]*:/, 'type.identifier'], // label
-      [/\b(?:add|addi|dadd|daddi|sub|mul|div|and|or|nor|sll|srl|lw|sw|ld|sd|li|move|syscall)\b/, 'keyword'],
-      [/\\.[a-zA-Z_][\w]*/, 'strong'], // direttive con punto
+      [/\b(?:add|dadd|daddi|daddui|dsub|dsubu|dmult|dmultu|mflo|mfhi|ddiv|and|andi|or|nor|dsll|dsslv|dsrl|dsrlv|dsra|dsrav|slt|sltu|slti|sltui|lb|lbu|sb|lw|lwu|sw|ld|sd|lh|lhu|sh|lui|j|jr|jal|jalr|beq|bne|move|syscall)\b/, 'keyword'],
+      [/\.[a-zA-Z_][\w]*/, 'strong'], // directives
       [/[#,]/, 'delimiter'],
-      [/\$[a-z0-9]+/, 'variable'],
+      [/\br(?:\d{1,2})\b/, 'string'],
       [/\d+/, 'number'],
-      [/".*?"/, 'string'],
-      [/;.*/, 'comment'], // commento
+      [/".*?"/, 'regexp'],
+      [/;.*/, 'comment'],
       [/[a-zA-Z_][\w]*/, 'identifier'],
     ]
   }

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -12,11 +12,14 @@ monaco.languages.register({ id: 'mips' });
 monaco.languages.setMonarchTokensProvider('mips', {
   tokenizer: {
     root: [
+      [/^[ \t]*[a-zA-Z_][\w]*:/, 'type.identifier'], // label
       [/\b(?:add|addi|dadd|daddi|sub|mul|div|and|or|nor|sll|srl|lw|sw|ld|sd|li|move|syscall)\b/, 'keyword'],
+      [/\\.[a-zA-Z_][\w]*/, 'strong'], // direttive con punto
       [/[#,]/, 'delimiter'],
       [/\$[a-z0-9]+/, 'variable'],
       [/\d+/, 'number'],
       [/".*?"/, 'string'],
+      [/;.*/, 'comment'], // commento
       [/[a-zA-Z_][\w]*/, 'identifier'],
     ]
   }


### PR DESCRIPTION
This simple PR completes the missing classes of tokens (registers, directives, etc...) and also add all the missing instructions of MIPS64. See effect below.
**OLD ----------------->**
<img width="580" alt="old_syntax" src="https://github.com/user-attachments/assets/3220cc9f-1ac8-4312-933f-b9619cc15044" />
**NEW ---------------->**
<img width="590" alt="new_syntax" src="https://github.com/user-attachments/assets/0403d91a-ce8f-4f56-9b98-6d555687f776" />
