### PR TITLE
Fixed hex parsing

### DIFF
--- a/src/main/java/org/edumips64/client/ResultFactory.java
+++ b/src/main/java/org/edumips64/client/ResultFactory.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import com.google.gwt.json.client.JSONArray;
 
 import org.edumips64.core.CPU;
+import org.edumips64.core.IrregularStringOfBitsException;
 import org.edumips64.core.Memory;
 import org.edumips64.core.Register;
 import org.edumips64.core.CPU.CPUStatus;
@@ -109,15 +110,19 @@ public class ResultFactory {
 
             JSONArray cellArray = new JSONArray();
             cells.forEach((address, element) -> {
-                cellArray.set(cellArray.size(), new FluentJsonObject()
-                        .put("address_hex", element.getAddressHex())
-                        .put("address", element.getAddress())
-                        .put("value", element.getValue())
-                        .put("value_hex", element.getValueHex())
-                        .put("label", element.getLabel())
-                        .put("code", element.getCode())
-                        .put("comment",element.getComment())
-                        .toJsonObject());
+                try {
+                    cellArray.set(cellArray.size(), new FluentJsonObject()
+                            .put("address_hex", element.getAddressHex())
+                            .put("address", element.getAddress())
+                            .put("value", element.getValue())
+                            .put("value_hex", element.getHexString())
+                            .put("label", element.getLabel())
+                            .put("code", element.getCode())
+                            .put("comment",element.getComment())
+                            .toJsonObject());
+                } catch (IrregularStringOfBitsException e) {
+                    throw new RuntimeException(e);
+                }
             });
             memoryJson.put("cells", cellArray);
 

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -604,6 +604,8 @@ public class Parser {
                     } else if (type == 'I') {
                       long immediateValue = 0;
                       String errorMessage = "";
+                      boolean is_label = false;
+                      boolean is_hex =  (paramValue.length() >= 3 && paramValue.substring(0, 2).compareToIgnoreCase("0x") == 0);
 
                       try {
                         immediateValue = Converter.parseImmediate(paramValue);
@@ -613,19 +615,25 @@ public class Parser {
                         try {
                           tmpMem = symTab.getCell(paramValue.trim());
                           immediateValue = tmpMem.getAddress();
+                          is_label = true;
                         } catch (MemoryElementNotFoundException ex) {
                           errorMessage = "INVALIDIMMEDIATE";
                         }
                       }
+                      // when hexadecimal, the range 32768 to 65536 is actually
+                      // the signed value will be between -32738 and -1
+                      // for example: 0xffff is not 65536 but -1
+                      if ( is_hex ) {
+                        if ( immediateValue >= 32768 && immediateValue<=65535)
+                          immediateValue -= 65536;
+                        else if (immediateValue>65535)
+                          errorMessage = "IMMEDIATE_TOO_LARGE";
+                      }
 
-                      // too large if converted as unsigned 16 bits
-                      if (errorMessage.isEmpty() && (immediateValue > 65535)) {
+                      // after all, the decimal should not exceed the 16 bit signed range
+                      if (errorMessage.isEmpty() && ( immediateValue< -32768 || immediateValue > 32767)) {
                         errorMessage = "IMMEDIATE_TOO_LARGE";
                         immediateValue = 0;
-                      }
-                      // valid 16 unsigned that should be interpreted as signed
-                      if (immediateValue >= 32768 && immediateValue<=65535) {
-                        immediateValue -= 65536;
                       }
 
                       // Casting to int is safe because we know the value is between -32768 and 32767.

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -1050,6 +1050,10 @@ public class Parser {
       boolean is_hex = (Converter.isHexNumber(val));
       if (is_hex) {
         try {
+          // handle the corner case of unlimited hex strings
+          if (numBit ==64 && is_hex && val.length()>18) {
+            throw new IrregularStringOfHexException();
+          }
           val = Converter.hexToLong(val);
         } catch (IrregularStringOfHexException e) {
           errors.addError("INVALIDVALUE", row, i + 1, line);

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -618,9 +618,14 @@ public class Parser {
                         }
                       }
 
-                      if (errorMessage.isEmpty() && (immediateValue < -32768 || immediateValue > 32767)) {
+                      // too large if converted as unsigned 16 bits
+                      if (errorMessage.isEmpty() && (immediateValue > 65535)) {
                         errorMessage = "IMMEDIATE_TOO_LARGE";
                         immediateValue = 0;
+                      }
+                      // valid 16 unsigned that should be interpreted as signed
+                      if (immediateValue >= 32768 && immediateValue<=65535) {
+                        immediateValue -= 65536;
                       }
 
                       // Casting to int is safe because we know the value is between -32768 and 32767.


### PR DESCRIPTION
This PR solves the following:

- In .data section, hex strings unreasonable long hex strings are checked before any conversion. For example, there's no chance of trying to apply conversion to something that is > 18 chars trimmed (8 bytes + 0x).
- In .data section, each hex string is checked against its actual size  (byte, word16 etc...) , not according some converted value. You should be able to write .byte 0xff to put 8 ones somewhere.
- In code, now is possible to use all the 16 bits of immediate in hex strings
- The mem section in webUI suffered a little bug in displaying big hex values, due to unmotivated usage of a different method rather the re-using the same value used in the Java version.