### PR TITLE
Fix isHexNumber logic

### DIFF
--- a/src/main/java/org/edumips64/core/Converter.java
+++ b/src/main/java/org/edumips64/core/Converter.java
@@ -585,10 +585,15 @@ public class Converter {
       return false;
     }
     
+    // Skip the 'x'/'X' prefix
+    cur++;
+
     // Check the rest of the number.
     for (; cur < num.length(); cur++) {
       char c = num.charAt(cur);
-      boolean isHexDigit = (c >= '0' || c <= '9') || (c >= 'a' || c <= 'f') || (c >= 'A' || c <= 'F');
+      boolean isHexDigit = (c >= '0' && c <= '9')
+          || (c >= 'a' && c <= 'f')
+          || (c >= 'A' && c <= 'F');
       if (!isHexDigit) {
         return false;
       }

--- a/src/test/java/org/edumips64/core/ConverterIsHexNumberTest.java
+++ b/src/test/java/org/edumips64/core/ConverterIsHexNumberTest.java
@@ -19,6 +19,7 @@ public class ConverterIsHexNumberTest {
             {"", false}, {"+", false}, {"-", false}, {" ", false}, {"++", false},
             {"0", false}, {"+0", false}, {"-0", false}, {"00000000000", false},
             {"0x", false}, {"0X", false},
+            {"0xG", false}, {"0xhello", false}, {"0x1G3", false},
             {"0xFF", true}, {"0XFF", true}, {"0x1", true}, {"0x0", true}
         });
 


### PR DESCRIPTION
## Summary
- extend parameterized tests for `isHexNumber` with invalid hex cases
- fix `Converter.isHexNumber` logic

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68628c1dabb48328af48fc3c0c440c07