### PR TITLE
Fix typo and comment

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -21,7 +21,7 @@
 #### Dev Container
 All requirements are available in the Development Container image described in the `.devcontainer/devcontainer.json` dev container. See https://containers.dev/ for documentation on dev containers.
 
-Github codespaces will use the dev container by default and give you a fully set up dev enviroment, useable for desktop, web and documentation development work.
+Github codespaces will use the dev container by default and give you a fully set up dev environment, useable for desktop, web and documentation development work.
 
 #### List of requirements
 

--- a/src/main/java/org/edumips64/core/Memory.java
+++ b/src/main/java/org/edumips64/core/Memory.java
@@ -41,7 +41,7 @@ public class Memory {
 
   /** Instruction offset limits in bytes */
   public static final int MAX_OFFSET_BYTES = 32768;  // 2^15
-  public static final int MIN_OFFSET_BYTES = -32767; // -2^15 - 1
+  public static final int MIN_OFFSET_BYTES = -32767; // -(2^15) + 1
 
   // Data structures for the data and code memory. In both maps, the key is represented by the index of the element.
   // The index is derived by taking the address of the given element and dividing it by its width (8 for the memory,


### PR DESCRIPTION
## Summary
- fix 'enviroment' typo in developer guide
- correct MIN_OFFSET_BYTES comment

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862892cfc188328b613dcc526f47e8d