### PR TITLE
ci: add caching and skip heavy jobs for bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'microsoft'
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -90,6 +91,7 @@ jobs:
     name: Build Windows MSI
     runs-on: windows-latest
     needs: build-desktop
+    if: ${{ github.event_name != 'pull_request_target' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]') }}
     steps:
         - uses: actions/checkout@v6
           with:
@@ -133,6 +135,7 @@ jobs:
         with:
           java-version: 17
           distribution: 'microsoft'
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -140,9 +143,18 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install JS dependencies
         run: npm install
+
+      - name: Cache GWT unit cache
+        uses: actions/cache@v4
+        with:
+          path: gwt-unitCache
+          key: gwt-${{ hashFiles('src/main/java/**/*.java') }}
+          restore-keys: |
+            gwt-
 
       - name: Build JS Worker (Java → JS), including HTML docs
         run: ./gradlew webapp
@@ -241,9 +253,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install JS dependencies
         run: npm install
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install
       # Run tests against the deployed code.
       - name: Run web tests against deployed code
@@ -259,6 +279,7 @@ jobs:
   build-snap:
     name: Build Snapcraft package
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request_target' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -275,6 +296,7 @@ jobs:
     name: Test Snapcraft package
     runs-on: ubuntu-latest
     needs: build-snap
+    if: ${{ github.event_name != 'pull_request_target' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]') }}
     steps:
       - uses: actions/download-artifact@v7.0.0
         name: Download snap package
@@ -291,6 +313,7 @@ jobs:
     name: Build Electron applications
     runs-on: ${{ matrix.os }}
     needs: build-web
+    if: ${{ github.event_name != 'pull_request_target' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]') }}
     strategy:
       matrix:
         include:
@@ -327,6 +350,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
           
       # Install dependencies
       - name: Install JS dependencies


### PR DESCRIPTION
## Changes

### 1. Add CI caching (speeds up all builds)

| Cache | Jobs | Key |
|-------|------|-----|
| Gradle dependencies | build-desktop, build-web | Built-in setup-java cache |
| npm dependencies | build-web, test-web, build-electron | Built-in setup-node cache |
| GWT unit cache | build-web | Hash of Java source files |
| Playwright browsers | test-web | Hash of package-lock.json |

Expected impact: **30-50% faster CI runs** on cache hits (especially Gradle and npm downloads).

### 2. Skip heavy packaging jobs for bot PRs

The following jobs are now skipped when the PR author is dependabot or renovate:
- **build-msi** (Windows MSI packaging)
- **build-snap** + **test-snap** (Snapcraft packaging)
- **build-electron** (3x Electron builds: Linux, macOS, Windows)

These packaging jobs are unnecessary for dependency-only updates. The core validation still runs:
- build-desktop (Java compile + tests + docs + JAR)
- build-web (GWT + webpack)
- deploy-staging + test-web (Playwright E2E tests)

Expected impact: **~15 minutes saved per bot PR** (eliminates 5 unnecessary jobs including 3 cross-platform Electron builds).

### Non-bot PRs

All jobs continue to run as before for human-authored PRs, push events, and scheduled runs.
