### PR TITLE
Force UTF-8 on CLI output to fix garbled localized help

### DIFF
--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -63,6 +63,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.*;
 import javax.swing.event.*;
@@ -134,9 +138,20 @@ public class Main {
   }
 
   public static void main(String args[]) {
+    // Force stdout/stderr to UTF-8 so localized strings (e.g. CLI help in
+    // Chinese) render correctly even when the JVM's default file.encoding
+    // is a non-UTF-8 codepage (common on Windows or with LANG=C).
+    System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
+    System.setErr(new PrintStream(System.err, true, StandardCharsets.UTF_8));
+
     Main mm = new Main();
     Args cliArgs = new Args();
     CommandLine commandLine = new CommandLine(cliArgs);
+    // Picocli wraps the output streams in PrintWriters that use Charset.defaultCharset(),
+    // which can drop non-ASCII characters from localized usage messages on systems where
+    // the default charset is not UTF-8 (e.g. Windows or LANG=C). Force UTF-8 explicitly.
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true));
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(System.err, StandardCharsets.UTF_8), true));
     if (commandLine.execute(args) != 0 || commandLine.isUsageHelpRequested() || commandLine.isVersionHelpRequested()) {
       System.exit(0);
     }

--- a/src/main/java/org/edumips64/utils/cli/Cli.java
+++ b/src/main/java/org/edumips64/utils/cli/Cli.java
@@ -12,6 +12,10 @@ import org.edumips64.utils.io.StdOutWriter;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
 @Command(name="", resourceBundle = "CliMessages", subcommands = {
         StepCommand.class,
         RunCommand.class,
@@ -44,7 +48,10 @@ public class Cli implements Runnable {
 
     @Command(name = "help")
     void help() {
-        CommandLine.usage(this, System.out);
+        // Use an explicit UTF-8 PrintWriter so localized (e.g. Chinese) usage
+        // text isn't mangled on systems where Charset.defaultCharset() isn't UTF-8.
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);
+        new CommandLine(this).usage(pw);
     }
 
     @Command(name = "reset")


### PR DESCRIPTION
Picocli wraps the output streams in PrintWriters that use Charset.defaultCharset(). On systems where the default charset isn't UTF-8 (e.g. Windows with a non-Latin codepage, or a JVM launched with LANG=C), non-ASCII characters in localized usage messages are silently replaced with '?', as reported in #787 for the Chinese CLI translation.

Force UTF-8 explicitly:
- Wrap System.out/System.err with UTF-8 PrintStreams at the very top of Main.main, so subsequent writes from anywhere in the app go through UTF-8.
- Pass UTF-8 PrintWriters to the top-level picocli CommandLine via setOut/setErr.
- In the interactive shell's 'help' command, build the picocli PrintWriter explicitly with UTF-8 instead of relying on the PrintStream-overload of CommandLine.usage, which would otherwise re-wrap with the platform default charset.

Verified locally with LANG=C and -Duser.language=zh: Chinese, Italian and English help output all render correctly.