### PR TITLE
Await code

### DIFF
--- a/src/webapp/components/HelpDialog.js
+++ b/src/webapp/components/HelpDialog.js
@@ -148,7 +148,7 @@ function useToc(language) {
       }
     }
 
-    fetchToc();
+    await fetchToc();
 
     return () => {
       abortController.abort();


### PR DESCRIPTION
While tracing code in src/webapp/components/HelpDialog.js I noticed what might be an issue: The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced. Let me know if the approach doesn’t fit.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.