### PR TITLE
fix(core): correct R2 register alias from 'v1' to 'v0' (#1693)

### DIFF
--- a/src/main/java/org/edumips64/core/Register.java
+++ b/src/main/java/org/edumips64/core/Register.java
@@ -154,7 +154,7 @@ public class Register extends BitSet64 {
     registerAliases = new HashMap<>();
     registerAliases.put("R0", "zero");
     registerAliases.put("R1", "at");
-    registerAliases.put("R2", "v1");
+    registerAliases.put("R2", "v0");
     registerAliases.put("R3", "v1");
     registerAliases.put("R4", "a0");
     registerAliases.put("R5", "a1");

--- a/src/test/java/org/edumips64/core/RegisterTest.java
+++ b/src/test/java/org/edumips64/core/RegisterTest.java
@@ -95,4 +95,29 @@ public class RegisterTest extends BaseTest {
     register.reset();
     assertEquals(0L, register.getValue());
   }
+
+  /**
+   * Regression test for the MIPS ABI register alias table.
+   *
+   * Prior to this test, R2 was incorrectly aliased to "v1" (a duplicate of R3),
+   * instead of "v0" as defined by the MIPS O32/N32/N64 ABIs. The Web UI
+   * (and Swing UI) display these aliases next to each register, so the bug
+   * was user-visible.
+   *
+   * The expected mapping mirrors the MIPS register convention used elsewhere
+   * in the codebase (see GUIRegisters.java and Parser.java).
+   */
+  @Test
+  public void testRegisterAliases() {
+    String[] expectedAliases = {
+        "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3",
+        "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7",
+        "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
+        "t8", "t9", "k0", "k1", "gp", "sp", "fp", "ra"
+    };
+    for (int i = 0; i < expectedAliases.length; i++) {
+      Register r = new Register("R" + i);
+      assertEquals("Wrong alias for R" + i, expectedAliases[i], r.getAlias());
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #1693.

R2 was aliased to `v1` in `Register.java`, duplicating R3's alias. Per the MIPS O32/N32/N64 ABI, R2 is `v0` (first return value register) and R3 is `v1` (second return value register).

The bug surfaced in the Web UI register panel as `R2 (v1)` instead of `R2 (v0)` — and also affected the Swing UI, since both consume the same alias map. Notably, the canonical mapping was already correct in `GUIRegisters.java` and `Parser.java`; only `Register.java` was out of sync.

## Changes

- `src/main/java/org/edumips64/core/Register.java`: one-character fix (`v1` → `v0` for R2).
- `src/test/java/org/edumips64/core/RegisterTest.java`: new `testRegisterAliases` regression test that asserts the full 32-entry ABI alias map. Any future drift between `Register.java` and the canonical convention used in `GUIRegisters.java` / `Parser.java` will now fail at build time.

## Test Plan

- [x] `./gradlew test --tests org.edumips64.core.RegisterTest` — all 10 tests pass (9 existing + 1 new).
- [x] New test fails on `main` (verified the assertion at index 2 catches the bug) and passes on this branch.

## Notes

Discovered during a dogfooding pass of https://web.edumips.org. See #1693 for the original report (with screenshot of the mislabeled register panel).