### PR TITLE
fix(web): default sample loads with zero issues (#1694)

### DIFF
--- a/src/test/webapp/deprecated-warnings.spec.js
+++ b/src/test/webapp/deprecated-warnings.spec.js
@@ -1,25 +1,44 @@
 const { test, expect } = require('./fixtures');
-const { targetUri, waitForPageReady, removeOverlay, waitForRunningState } = require('./test-utils');
+const { targetUri, waitForPageReady, removeOverlay, loadProgram } = require('./test-utils');
 
 /**
  * Tests for the behavior of deprecated-instruction warnings.
  *
- * Regression tests for https://github.com/EduMIPS64/edumips64/issues related
- * to "Deprecated Instructions weird behaviours":
- *   1. The deprecated instruction in the sample code must be flagged as a
- *      warning as soon as the page loads, without requiring the user to
- *      edit the code first.
+ * Regression tests for the original "Deprecated Instructions weird behaviours"
+ * report:
+ *   1. A program containing a deprecated WinMIPS64 instruction (e.g. `bnez`)
+ *      must be flagged as a warning by the syntax checker.
  *   2. After loading code that contains only warnings (no errors), the
  *      hover provider in the editor must still show the per-instruction
  *      metadata tooltip (Address/OpCode/Binary/Hex/CPU Stage).
+ *
+ * Note: the default sample program intentionally uses the canonical
+ * `bne … r0` form (instead of `bnez`) so that first-time visitors land
+ * on a clean Issues panel. These tests therefore inject their own
+ * deprecated snippet rather than relying on the default sample.
  */
 
-test('deprecated instruction in sample is flagged on initial load', async ({ page }) => {
+const DEPRECATED_PROGRAM = `; Minimal program exercising a deprecated WinMIPS64 instruction.
+.data
+.code
+\tdaddi\tr10, r0, 3
+loop:
+\tdaddi\tr10, r10, -1
+\tbnez\tr10, loop
+\tsyscall\t0
+`;
+
+test('deprecated instruction is flagged by the syntax checker', async ({ page }) => {
   await page.goto(targetUri);
   await waitForPageReady(page);
+  await removeOverlay(page);
 
-  // The Issues accordion should show the deprecated-instruction warning for
-  // the sample program, without the user having had to edit anything.
+  // Replace the default sample with a program that uses `bnez` (a deprecated
+  // WinMIPS64 alias). The syntax checker should raise a warning, but the
+  // program must still be loadable (no errors).
+  await loadProgram(page, DEPRECATED_PROGRAM);
+
+  // The Issues accordion should show the deprecated-instruction warning.
   const warningItem = page.locator('.error-list-item').first();
   await expect(warningItem).toBeVisible({ timeout: 10000 });
 
@@ -32,21 +51,24 @@ test('hover tooltip works after loading code with a warning', async ({ page }) =
   await waitForPageReady(page);
   await removeOverlay(page);
 
-  // Wait for the initial syntax check to populate the Issues panel.
-  await expect(page.locator('.error-list-item').first()).toBeVisible({ timeout: 10000 });
-
-  // Load the (sample) program, which contains a deprecated-instruction warning.
-  await page.waitForSelector('#load-button:not([disabled])', { timeout: 10000 });
-  await page.click('#load-button');
-  await waitForRunningState(page);
-
-  // Trigger the Monaco hover on an instruction line (line 17, `daddi r10, r0, 1000`).
-  // If `parsedInstructions` was wrongly cleared because the program has
+  // Load a program that contains a deprecated-instruction warning. If
+  // `parsedInstructions` was wrongly cleared because the program has
   // warnings, the hover provider would return nothing and no tooltip would
   // be rendered.
+  await loadProgram(page, DEPRECATED_PROGRAM);
+
+  // Trigger the Monaco hover on the first instruction line of the program
+  // (`daddi r10, r0, 3`).
   const hoverContents = await page.evaluate(async () => {
     const { editor } = window;
-    editor.setPosition({ lineNumber: 17, column: 5 });
+    const model = editor.getModel();
+    // Find the first non-blank line in `.code` (the daddi above).
+    let target = 1;
+    for (let i = 1; i <= model.getLineCount(); i++) {
+      const text = model.getLineContent(i).trim();
+      if (text.startsWith('daddi')) { target = i; break; }
+    }
+    editor.setPosition({ lineNumber: target, column: 5 });
     editor.focus();
     editor.trigger('test', 'editor.action.showHover', {});
     await new Promise((r) => setTimeout(r, 1000));

--- a/src/test/webapp/sample-program-clean.spec.js
+++ b/src/test/webapp/sample-program-clean.spec.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('./fixtures');
+const { targetUri, waitForPageReady } = require('./test-utils');
+
+/**
+ * Regression test for the "default sample triggers a permanent Issues 1
+ * badge" report: a brand-new visitor should land on a clean Issues panel.
+ * The default sample must therefore contain no warnings or errors.
+ */
+test('default sample loads with zero issues on a fresh page', async ({ page }) => {
+  await page.goto(targetUri);
+  await waitForPageReady(page);
+
+  // No `.error-list-item` rows should be rendered, and the Issues accordion
+  // header must not show a count chip (i.e. just "Issues", not "Issues 1").
+  await expect(page.locator('.error-list-item')).toHaveCount(0);
+  await expect(
+    page.getByRole('heading', { name: /^Issues\s*\d+/ })
+  ).toHaveCount(0);
+});

--- a/src/webapp/data/SampleProgram.js
+++ b/src/webapp/data/SampleProgram.js
@@ -20,8 +20,10 @@ loop:
 	
 	daddi 	r10, r10, -1
 
-	; deprecated instruction, added on purpose to show how deprecated instructions are flagged as warnings.
-	bnez	r10, loop
+	; Loop back to the start until r10 reaches zero. We use 'bne … r0'
+	; (canonical MIPS64) instead of the WinMIPS64-only 'bnez' alias so
+	; that the default sample loads with zero warnings.
+	bne	r10, r0, loop
 
 	; Call SYSCALL 5 (printf())
 	daddi     r5, r0, format_str


### PR DESCRIPTION
## Summary

Fixes #1694.

The default sample program shown on the Web UI used the WinMIPS64-only `bnez` alias on line 23 — intentionally, to demonstrate how deprecated instructions are flagged. The side effect was that every first-time visitor landed on a red `Issues 1` badge in the header, even though the program runs to completion. That's a poor first impression and makes the simulator look broken.

This PR replaces `bnez r10, loop` with the canonical MIPS64 form `bne r10, r0, loop` and updates the comment so the loop is still self-explanatory. The deprecated-instruction warning machinery is unchanged: anyone who writes (or pastes) `bnez` still sees the warning, and the editor hover tooltip still works.

## Changes

- `src/webapp/data/SampleProgram.js`: `bnez r10, loop` → `bne r10, r0, loop`; comment rewritten.
- `src/test/webapp/sample-program-clean.spec.js`: **new** regression test asserting that a fresh page load has zero `.error-list-item` rows and no Issues count chip.
- `src/test/webapp/deprecated-warnings.spec.js`: rewritten so the two existing tests inject their own deprecated snippet via the `loadProgram` helper instead of depending on the sample carrying one. The hover-tooltip test now locates the `daddi` line by content rather than a hard-coded line number, so it stays robust against future sample edits.

## Test Plan

- [x] Local repo lint pass (no new ESLint diagnostics introduced).
- [ ] CI Playwright suite (run on this PR) — verifies both the new clean-sample test and the rewritten deprecated-warnings tests pass against the built Web UI.

## Notes

Discovered during a dogfooding pass of https://web.edumips.org. See #1694 for the original report.