### PR TITLE
fix(web): accessibility quick wins (lang, h1, skip-link, help aria-label, status live region, help pilcrows)

### DIFF
--- a/src/test/webapp/a11y-quick-wins.spec.js
+++ b/src/test/webapp/a11y-quick-wins.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('./fixtures');
+const { targetUri, waitForPageReady } = require('./test-utils');
+
+/**
+ * Regression suite for the batch of accessibility quick-wins:
+ *   - #1700  <html lang>, document <h1>, skip-link
+ *   - #1699  Help IconButton accessible name
+ *   - #1705  CPU status pill announced as a live region
+ *   - #1698  Sphinx ¶ headerlinks hidden inside the embedded help iframe
+ */
+
+test.describe('accessibility quick wins', () => {
+  test('document has lang, single h1, and a skip link', async ({ page }) => {
+    await page.goto(targetUri);
+    await waitForPageReady(page);
+
+    // <html lang="en"> — needed so screen readers pick the right voice
+    // and so automated a11y tools (axe, Lighthouse) don't flag the page.
+    const lang = await page.evaluate(() => document.documentElement.lang);
+    expect(lang).toBe('en');
+
+    // Exactly one document-level <h1>. The visible UI uses h3 panel
+    // headings, so the page-level h1 is visually hidden.
+    await expect(page.locator('h1')).toHaveCount(1);
+    await expect(page.locator('h1')).toHaveText(/EduMIPS64/i);
+
+    // Skip link is present and points at the React mount node.
+    const skip = page.locator('a.skip-link');
+    await expect(skip).toHaveCount(1);
+    await expect(skip).toHaveAttribute('href', '#simulator');
+  });
+
+  test('help button has an accessible name', async ({ page }) => {
+    await page.goto(targetUri);
+    await waitForPageReady(page);
+
+    // Locating by role+name proves the IconButton exposes an accessible
+    // name to assistive tech (rather than just "button" with no label).
+    const helpBtn = page.getByRole('button', { name: /open help/i });
+    await expect(helpBtn).toBeVisible();
+  });
+
+  test('CPU status chip is exposed as a polite live region', async ({ page }) => {
+    await page.goto(targetUri);
+    await waitForPageReady(page);
+
+    // The chip is inside a tooltip wrapper; we target by role+name so
+    // any nesting changes don't break the test.
+    const status = page.getByRole('status', { name: /cpu status/i });
+    await expect(status).toBeVisible();
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('help iframe does not render Sphinx pilcrow permalinks', async ({ page }) => {
+    await page.goto(targetUri);
+    await waitForPageReady(page);
+
+    await page.getByRole('button', { name: /open help/i }).click();
+
+    // Wait for the help iframe to attach and load its index page.
+    const iframeLocator = page.locator('#help-iframe');
+    await expect(iframeLocator).toBeVisible();
+    const frame = page.frameLocator('#help-iframe');
+
+    // Heading should still render; Sphinx anchors should be hidden.
+    await expect(frame.locator('h1').first()).toBeVisible();
+    const visibleHeaderlinks = await frame.locator('a.headerlink:visible').count();
+    expect(visibleHeaderlinks).toBe(0);
+  });
+});

--- a/src/webapp/components/CpuStatusDisplay.js
+++ b/src/webapp/components/CpuStatusDisplay.js
@@ -24,6 +24,12 @@ const CpuStatusDisplay = ({ status }) => {
       color={color}
       size="small"
       style={{ textAlign: 'center', marginRight: "5px" }}
+      // Make the chip a polite live region so screen readers announce
+      // CPU state transitions (READY → RUNNING → STOPPED/HALTED).
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label={`CPU status: ${status}`}
     />
     </>
   );

--- a/src/webapp/components/Header.js
+++ b/src/webapp/components/Header.js
@@ -242,6 +242,7 @@ export default function Header(props) {
           color="inherit"
           className="help-button"
           id="help-button"
+          aria-label="Open help"
           onClick={() => {
             setDialogOpen(true);
           }}

--- a/src/webapp/components/HelpDialog.js
+++ b/src/webapp/components/HelpDialog.js
@@ -431,6 +431,13 @@ export default function HelpDialog(props) {
             .related, .sphinxsidebar, div.clearer {
               display: none !important;
             }
+            /* Hide Sphinx's per-heading "¶" permalink anchors. They are
+               useful in the standalone Sphinx site (right-click → copy
+               link), but inside our embedded help iframe they don't
+               navigate anywhere useful and just clutter every heading. */
+            a.headerlink {
+              display: none !important;
+            }
             .documentwrapper, .bodywrapper, .body {
               margin: 0 !important;
               width: 100% !important;

--- a/src/webapp/static/index.html
+++ b/src/webapp/static/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <title>EduMIPS64 Experimental Web Frontend</title>
@@ -11,12 +12,19 @@
     />
   </head>
   <body>
+    <!-- Skip link for keyboard / screen-reader users (WCAG 2.4.1). -->
+    <a class="skip-link" href="#simulator">Skip to simulator</a>
+
     <noscript>
       <div id="nojs">
         Your web browser must have JavaScript enabled in order for this
         application to display correctly.
       </div>
     </noscript>
+
+    <!-- Visually hidden top-level heading so the page has a single H1
+         (WCAG 1.3.1, 2.4.6). The visible app uses H3 panel headings. -->
+    <h1 class="visually-hidden">EduMIPS64 web simulator</h1>
 
     <!-- React mount node. -->
     <div id="simulator"></div>

--- a/src/webapp/static/style.css
+++ b/src/webapp/static/style.css
@@ -4,6 +4,42 @@ body {
   overflow: hidden;
 }
 
+/* Visually hide an element while keeping it available to assistive tech.
+   Used for the document-level <h1> in index.html (the visible UI uses
+   MUI panel headings at H3). */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Keyboard "skip to main content" link. Hidden until focused so it
+   doesn't disturb the visual layout but is the first stop in tab order. */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #1976d2;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 100000;
+  text-decoration: none;
+  font-family: 'Roboto', sans-serif;
+  border-radius: 0 0 4px 0;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid #fff;
+  outline-offset: -4px;
+}
+
 
 
 /* Define the grid of widgets. */


### PR DESCRIPTION
Batches four small accessibility fixes surfaced during a dogfood pass into a single PR (each one is 1–10 lines and they all touch the same area).

## Fixes

| Issue | Change |
|---|---|
| #1700 | `index.html` now declares `lang="en"`, has a visually-hidden document `<h1>`, and a focus-revealed skip link. New `.visually-hidden` and `.skip-link` rules added to `style.css`. |
| #1699 | `Header.js` Help `IconButton` gets `aria-label="Open help"`. |
| #1705 | `CpuStatusDisplay.js` `Chip` is now `role="status"`, `aria-live="polite"`, `aria-atomic="true"`, with an `aria-label` of `"CPU status: <state>"` so the announcement is meaningful out of context. |
| #1698 | `HelpDialog.js` injected stylesheet hides Sphinx's per-heading `¶` permalink anchors (`a.headerlink`) inside the embedded help iframe. |

## Tests

New Playwright spec `src/test/webapp/a11y-quick-wins.spec.js` with four
focused tests, one per issue:

- `document has lang, single h1, and a skip link`
- `help button has an accessible name`
- `CPU status chip is exposed as a polite live region`
- `help iframe does not render Sphinx pilcrow permalinks`

## Notes

- The visible UI keeps its MUI panel headings at H3; the new `<h1>` is
  visually hidden and only present so the document satisfies the
  "exactly one top-level heading" expectation that axe / Lighthouse flag.
- Headerlinks remain present in the standalone Sphinx site (not built
  here) — only the embedded iframe styles them out, since deep-links
  inside the iframe aren't shareable.
- The status pill keeps its color cue for sighted users; the
  `aria-label` prefix ("CPU status: …") only affects assistive tech.

Closes #1698
Closes #1699
Closes #1700
Closes #1705
