### PR TITLE
fix(swing): annotate intentional reference-identity comparisons (Codacy)

### DIFF
--- a/src/main/java/org/edumips64/ui/swing/GUIData.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIData.java
@@ -129,7 +129,9 @@ public class GUIData extends GUIComponent {
       public void mouseClicked(MouseEvent e) {
         Object source = e.getSource();
 
-        if ((source == theTable) && (theTable.getSelectedColumn() == 1)) {
+        // NOPMD - reference identity intentional: `source` is the event's
+        // source object, which IS theTable when this listener fires on theTable.
+        if ((source == theTable) && (theTable.getSelectedColumn() == 1)) { // NOPMD CompareObjectsWithEquals
           try {
             String value = CurrentLocale.getString("StatusBar.DECIMALVALUE") + " " +
                            CurrentLocale.getString("StatusBar.MEMORYCELL") +

--- a/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
@@ -215,7 +215,9 @@ class GUIRegisters extends GUIComponent {
       public void mouseClicked(MouseEvent e) {
         Object source = e.getSource();
 
-        if ((source == theTable)) {
+        // NOPMD - reference identity intentional: `source` is the event's
+        // source object, which IS theTable when this listener fires on theTable.
+        if ((source == theTable)) { // NOPMD CompareObjectsWithEquals
           try {
             //click on LO register
             if (theTable.getSelectedRow() == 32 && theTable.getSelectedColumn() == 1) {

--- a/src/main/java/org/edumips64/ui/swing/MultiLineBasicTableUI.java
+++ b/src/main/java/org/edumips64/ui/swing/MultiLineBasicTableUI.java
@@ -254,7 +254,9 @@ public class MultiLineBasicTableUI extends javax.swing.plaf.basic.BasicTableUI {
       if (cellRect.intersects(rect)) {
         drawn = true;
 
-        if ((header == null) || (aColumn != header.getDraggedColumn())) {
+        // NOPMD - reference identity intentional: getDraggedColumn() returns
+        // the same TableColumn instance the header is tracking; no equals().
+        if ((header == null) || (aColumn != header.getDraggedColumn())) { // NOPMD CompareObjectsWithEquals
           paintCell(g, cellRect, row, column);
         } else {
           // Paint a gray well in place of the moving column

--- a/src/test/java/org/edumips64/ui/swing/GUIHelpTest.java
+++ b/src/test/java/org/edumips64/ui/swing/GUIHelpTest.java
@@ -63,7 +63,9 @@ public class GUIHelpTest extends BaseTest {
     }
 
     for (LogRecord r : handler.records) {
-      if (r.getLevel() == Level.SEVERE && r.getMessage() != null
+      // NOPMD - reference identity intentional: java.util.logging.Level
+      // values are singleton constants; `==` is the standard idiom.
+      if (r.getLevel() == Level.SEVERE && r.getMessage() != null // NOPMD CompareObjectsWithEquals
           && r.getMessage().startsWith("Could not parse Help URL")) {
         fail("URI parsing should succeed for URLs with raw spaces, "
             + "but got SEVERE log: " + r.getMessage());


### PR DESCRIPTION
Closes #1716 (sub-issue of #222).

Each of the four `CompareObjectsWithEquals` sites flagged by Codacy uses `==` correctly:

| Site | Reason |
|---|---|
| `MultiLineBasicTableUI.java:257` | `getDraggedColumn()` returns the same `TableColumn` reference the header is tracking |
| `GUIData.java:132` | `source` is the event source and IS `theTable` |
| `GUIRegisters.java:218` | same as above |
| `GUIHelpTest.java:66` | `java.util.logging.Level` values are singletons; `==` against `Level.SEVERE` is the documented idiom |

This PR adds a 1-line rationale comment and inline `// NOPMD CompareObjectsWithEquals` suppression at each site. No behavior change. `./gradlew compileTestJava` clean.

No new tests needed — these are pure annotation changes.