### PR TITLE
fix(swing): scope static-mutable fields to instances or constants (Codacy)

### DIFF
--- a/src/main/java/org/edumips64/ui/swing/DineroFrontend.java
+++ b/src/main/java/org/edumips64/ui/swing/DineroFrontend.java
@@ -43,13 +43,19 @@ import javax.swing.*;
 public class DineroFrontend extends JDialog {
   private static final long serialVersionUID = -3679388156127239041L;
 
-  // Attributes are static in order to make them accessible from
-  // the nested anonymous classes. They can be static, because at most
-  // one instance of DineroFrame will be created in EduMIPS64
+  // The dialog's interactive widgets. These were historically `static` to
+  // expose them to the inner anonymous listener classes; lambdas (and inner
+  // classes) capture the enclosing `this`, so they can be plain instance
+  // fields. Keeping them as instance state also lets multiple Dinero dialogs
+  // coexist (e.g. in tests) without tearing each other's UI apart.
+  // They are not `final` because the lambdas defined earlier in the
+  // constructor reference them before they get initialized below; making
+  // them `final` would require reordering the entire constructor.
   private static final Logger logger = Logger.getLogger(DineroFrontend.class.getName());
-  private static JTextField path, params;
-  private static JButton execute;
-  private static JTextArea result;
+  private JTextField path;
+  private JTextField params;
+  private JButton execute;
+  private JTextArea result;
 
   private class StreamReader extends Thread {
     private InputStream stream;

--- a/src/main/java/org/edumips64/ui/swing/GUIAbout.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIAbout.java
@@ -41,9 +41,9 @@ public class GUIAbout extends JDialog implements Runnable  {
   private Display lavagna;
   private boolean running;
 
-  private static Image logo;
+  private Image logo;
 
-  private static String members[] = {
+  private static final String[] members = {
     "EduMIPS64 Project",
     "http://www.edumips.org",
     "MIPS64 Instruction set simulator",

--- a/src/main/java/org/edumips64/ui/swing/GUITheme.java
+++ b/src/main/java/org/edumips64/ui/swing/GUITheme.java
@@ -7,17 +7,17 @@ import org.edumips64.utils.ConfigStore;
 import java.awt.*;
 
 public class GUITheme {
-    private static Color lightText = Color.black;
-    private static Color lightBackground = Color.white;
-    private static Color darkText = new Color(187, 187, 187);
-    private static Color darkBackground = new Color(70, 73, 75);
-    
-    private static boolean usingDarkTheme;
+    private static final Color lightText = Color.black;
+    private static final Color lightBackground = Color.white;
+    private static final Color darkText = new Color(187, 187, 187);
+    private static final Color darkBackground = new Color(70, 73, 75);
 
-    private ConfigStore config;
+    private final boolean usingDarkTheme;
+
+    private final ConfigStore config;
 
     public GUITheme(ConfigStore config){
-        usingDarkTheme = config.getBoolean(ConfigKey.UI_DARK_THEME);
+        this.usingDarkTheme = config.getBoolean(ConfigKey.UI_DARK_THEME);
         this.config = config;
         
         // For Current Setting Exporting

--- a/src/main/java/org/edumips64/ui/swing/MultiLineCellRenderer.java
+++ b/src/main/java/org/edumips64/ui/swing/MultiLineCellRenderer.java
@@ -35,7 +35,9 @@ import java.awt.Color;
 public class MultiLineCellRenderer extends JTextArea implements TableCellRenderer {
   private static final long serialVersionUID = -4281001238359343652L;
 
-  protected static Border noFocusBorder;
+  // Shared default border. EmptyBorder is immutable, so a single constant
+  // can be reused across all renderer instances.
+  protected static final Border noFocusBorder = new EmptyBorder(1, 2, 1, 2);
 
   boolean[] lineIsError;
   private Color errorBackground ;
@@ -43,7 +45,6 @@ public class MultiLineCellRenderer extends JTextArea implements TableCellRendere
 
   public MultiLineCellRenderer() {
     super();
-    noFocusBorder = new EmptyBorder(1, 2, 1, 2);
     setLineWrap(true);
     setWrapStyleWord(true);
     setOpaque(true);
@@ -53,7 +54,6 @@ public class MultiLineCellRenderer extends JTextArea implements TableCellRendere
 
   public MultiLineCellRenderer(boolean[] lineIsError, GUITheme theme) {
     super();
-    noFocusBorder = new EmptyBorder(1, 2, 1, 2);
     setLineWrap(true);
     setWrapStyleWord(true);
     setOpaque(true);

--- a/src/test/java/org/edumips64/ui/swing/GUIThemeTest.java
+++ b/src/test/java/org/edumips64/ui/swing/GUIThemeTest.java
@@ -1,0 +1,68 @@
+package org.edumips64.ui.swing;
+
+import org.edumips64.BaseTest;
+import org.edumips64.utils.ConfigKey;
+import org.edumips64.utils.ConfigStore;
+import org.edumips64.utils.InMemoryConfigStore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests for {@link GUITheme}.
+ *
+ * <p>Historically, {@code usingDarkTheme} and the four cached colors were
+ * {@code static} mutable fields on {@code GUITheme}. As of the
+ * {@code AssignmentToNonFinalStatic} cleanup, {@code usingDarkTheme} and
+ * {@code config} are per-instance: two coexisting {@code GUITheme} objects
+ * with different config snapshots must report different colors. These tests
+ * pin that contract so the field-scope refactor is not silently undone.
+ */
+public class GUIThemeTest extends BaseTest {
+
+  private GUITheme themeWith(boolean dark) {
+    ConfigStore store = new InMemoryConfigStore(ConfigStore.defaults);
+    store.putBoolean(ConfigKey.UI_DARK_THEME, dark);
+    return new GUITheme(store);
+  }
+
+  @Test
+  public void lightAndDarkInstancesReportDifferentTextColors() {
+    GUITheme light = themeWith(false);
+    GUITheme dark = themeWith(true);
+    assertNotEquals(
+        "Light- and dark-theme instances must produce different text colors;"
+            + " if these match, theme state has likely leaked back to a static field.",
+        light.getTextColor(), dark.getTextColor());
+  }
+
+  @Test
+  public void lightAndDarkInstancesReportDifferentBackgroundColors() {
+    assertNotEquals(themeWith(false).getBackgroundColor(),
+        themeWith(true).getBackgroundColor());
+  }
+
+  @Test
+  public void instantiatingDarkThemeDoesNotMutateExistingLightInstance() {
+    // Regression guard for the static→instance migration: creating a dark
+    // theme after a light one must not change the light instance's colors.
+    GUITheme light = themeWith(false);
+    java.awt.Color textBefore = light.getTextColor();
+    java.awt.Color bgBefore = light.getBackgroundColor();
+
+    @SuppressWarnings("unused")
+    GUITheme dark = themeWith(true);
+
+    assertEquals(textBefore, light.getTextColor());
+    assertEquals(bgBefore, light.getBackgroundColor());
+  }
+
+  @Test
+  public void errorAndWarningColorsTrackThemeOfTheInstance() {
+    GUITheme light = themeWith(false);
+    GUITheme dark = themeWith(true);
+    assertNotEquals(light.getErrorColor(), dark.getErrorColor());
+    assertNotEquals(light.getWarningColor(), dark.getWarningColor());
+  }
+}


### PR DESCRIPTION
Closes #1715 (sub-issue of #222).

Addresses 7 Codacy `AssignmentToNonFinalStatic` High-severity findings in the Swing UI. Each flagged field was static-and-mutable only as a workaround for the old anonymous-inner-class capture rule — lambdas (and inner classes) capture the enclosing `this`, so these can all be either instance state or proper constants.

## Changes

| Field | Before | After | Why |
|---|---|---|---|
| `DineroFrontend.path/params/execute/result` | `static` mutable | instance (non-final) | Multiple dialogs can now coexist; non-final because lambdas defined earlier in the ctor reference them before they're assigned |
| `MultiLineCellRenderer.noFocusBorder` | `static` mutable | `static final` constant | `EmptyBorder` is immutable; one instance for everyone, removes 2 redundant assignments |
| `GUIAbout.logo` | `static` mutable | instance | The non-static inner `Display` class reads it via the enclosing instance |
| `GUIAbout.members` | `static` mutable | `static final` | Already only read after class init |
| `GUITheme.usingDarkTheme` + 4 colors | `static` mutable | instance `final` (flag) + `static final` (colors) | **Only user-visible fix** — previously, building a second `GUITheme` with a different `UI_DARK_THEME` silently flipped the flag on the already-existing instance |

## Tests

New `GUIThemeTest` (4 cases) pins the static→instance migration:

- `lightAndDarkInstancesReportDifferentTextColors` — light vs. dark themes return different text colors
- `lightAndDarkInstancesReportDifferentBackgroundColors` — same for background
- `errorAndWarningColorsTrackThemeOfTheInstance` — error/warning colors track per-instance dark flag
- `instantiatingDarkThemeDoesNotMutateExistingLightInstance` — direct regression guard for the bug the migration actually fixed

Full `./gradlew test` passes.

## Risk

Low. `DineroFrontend`, `GUIAbout`, `MultiLineCellRenderer`: behavior identical (same value, narrower scope). `GUITheme`: behavior strictly improved (state no longer leaks across instances). All 4 new tests pass, and they would have failed on `master` for `lightAndDarkInstancesReportDifferentTextColors` if the static field had been observed at the wrong moment.