### PR TITLE
Fix #1723: stop reinstalling the Monaco tokenizer on every render

### DIFF
--- a/src/test/webapp/syntax-highlighting-during-run.spec.js
+++ b/src/test/webapp/syntax-highlighting-during-run.spec.js
@@ -1,0 +1,106 @@
+// Regression test for issue #1723: syntax highlighting disappears while a
+// program is executing.
+//
+// Root cause: Code.js used to call monaco.languages.setMonarchTokensProvider
+// in the component's render body. Each Run All step triggers many parent
+// re-renders (one per pipeline update), so the tokenizer provider was
+// reinstalled several times per second. Each reinstall invalidates already-
+// tokenized lines and starts an async re-tokenization pass, during which
+// Monaco renders the affected lines with the default token class — i.e.
+// plain black text with no syntax colours.
+//
+// Detection strategy: a `.code` line that contains an instruction mnemonic
+// is normally split by Monaco into several spans, at least one of which is
+// the keyword span coloured blue. While the regression is active, the
+// tokenizer is constantly being torn down, so every span on those lines
+// renders as `mtk1` with the default colour `rgb(0, 0, 0)`. We sample the
+// editor DOM repeatedly during a Run All and fail the test if every span
+// on every mnemonic-bearing line is black for the entire sample window.
+const { test, expect } = require('./fixtures');
+const { targetUri, waitForPageReady } = require('./test-utils');
+
+async function sampleMnemonicLines(page) {
+  return page.evaluate(() => {
+    const lines = [...document.querySelectorAll('.monaco-editor .view-line')];
+    return lines
+      .map((line) => {
+        const text = line.innerText.replace(/\u00a0/g, ' ');
+        const spans = [...line.querySelectorAll('span[class^="mtk"]')].map(
+          (s) => ({
+            color: getComputedStyle(s).color,
+            cls: s.className,
+          }),
+        );
+        return { text, spans };
+      })
+      .filter((l) =>
+        /\b(daddi|bne|nop|syscall|sd|sw|ld|lw|add|sub|halt)\b/.test(l.text),
+      );
+  });
+}
+
+function lineLooksUnhighlighted(line) {
+  if (line.spans.length === 0) return false;
+  return line.spans.every((s) =>
+    /^rgb\(\s*0\s*,\s*0\s*,\s*0\s*\)$/.test(s.color),
+  );
+}
+
+test.describe('Syntax highlighting during execution (#1723)', () => {
+  test('instruction lines keep their colour while Run All is in progress', async ({
+    page,
+  }) => {
+    await page.goto(targetUri);
+    await waitForPageReady(page);
+
+    // Use the default sample program that ships with the page — it is long
+    // enough that the re-tokenization storm caused by the bug can be
+    // observed reliably.
+    await page.waitForSelector('#load-button:not([disabled])', {
+      timeout: 10000,
+    });
+    await page.click('#load-button');
+    await page.waitForSelector('#step-button:not([disabled])', {
+      timeout: 10000,
+    });
+
+    // Sanity check: the editor exposes mnemonic-bearing lines after Load.
+    const idle = await sampleMnemonicLines(page);
+    expect(idle.length).toBeGreaterThan(0);
+
+    // Kick off Run All. During the run we keep polling the DOM and assert
+    // that at least one mnemonic-bearing line continues to expose a non-
+    // black span. With the bug present, every poll sees only mtk1/black.
+    await page.click('#run-button');
+
+    let badPolls = 0;
+    let totalPolls = 0;
+    let lastBad = null;
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline) {
+      const samples = await sampleMnemonicLines(page);
+      if (samples.length > 0) {
+        totalPolls += 1;
+        if (samples.every(lineLooksUnhighlighted)) {
+          badPolls += 1;
+          lastBad = samples;
+        }
+      }
+      const finished = await page
+        .locator('#clear-code-button')
+        .isEnabled()
+        .catch(() => false);
+      if (finished) break;
+      await page.waitForTimeout(80);
+    }
+
+    expect(totalPolls).toBeGreaterThan(0);
+    // Allow at most one polling sample to catch a re-tokenization gap; if
+    // *every* sample during the run shows fully-black mnemonic lines the
+    // tokenizer is getting stomped continuously.
+    expect(
+      badPolls,
+      `${badPolls}/${totalPolls} polls during Run All saw all mnemonic lines unhighlighted (#1723). Last sample: ${JSON.stringify(lastBad).slice(0, 600)}`,
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -10,7 +10,6 @@ import * as monacoEditor from 'monaco-editor';
 monacoEditor.languages.register({ id: 'mips' });
 
 const Code = (props) => {
-
   const [monaco, setMonaco] = useState(null);
   const [editor, setEditor] = useState(null);
   const [vimInstance, setVimInstance] = useState(null); // new state for Vim instance
@@ -23,23 +22,81 @@ const Code = (props) => {
   // Maps line of code to CPU stage.
   const [stageMap, setStageMap] = useState(new Map());
 
-  // Dynamically build the syntax highlighting regex for instructions.
-  var instructionRegex = new RegExp(`\\b(${props.validInstructions})\\b`)
-  monacoEditor.languages.setMonarchTokensProvider('mips', {
-    tokenizer: {
-      root: [
-        [/^[ \t]*[a-zA-Z_][\w]*:/, 'type.identifier'], // label
-        [instructionRegex, 'keyword'],
-        [/\.[a-zA-Z_][\w]*/, 'strong'], // directives
-        [/[#,]/, 'delimiter'],
-        [/\br(?:\d{1,2})\b/, 'string'],
-        [/\d+/, 'number'],
-        [/".*?"/, 'regexp'],
-        [/;.*/, 'comment'],
-        [/[a-zA-Z_][\w]*/, 'identifier'],
-      ]
-    }
-  });
+  // Install our MIPS syntax highlighting provider.
+  //
+  // Background and pitfalls
+  // -----------------------
+  //
+  // monaco-editor ships its own stock `mips` Monarch grammar via
+  // `basic-languages/mips/mips.contribution.js`. That contribution registers
+  // a `TokensProviderFactory` whose `create()` is async — Monaco only awaits
+  // it the first time a `mips` model needs tokens, and on resolution it
+  // calls `TokenizationRegistry.register('mips', stockSupport)`, which
+  // overwrites whatever was installed synchronously by
+  // `setMonarchTokensProvider`. So a plain `setMonarchTokensProvider` call
+  // loses a race to the stock grammar a few hundred ms after the editor
+  // mounts.
+  //
+  // The previous version of this file masked the race by reinstalling our
+  // provider in the component render body, which fires many times per
+  // second while a program runs (each pipeline state update re-renders the
+  // Simulator). That kept our provider on top, but every reinstall
+  // invalidates Monaco's tokenization state and triggers an async retoken-
+  // ization pass during which lines render with the default `mtk1` token
+  // class — i.e. plain black text. That was the run-time "flicker" bug
+  // reported in #1723.
+  //
+  // The robust fix is to *replace* the stock factory rather than fight it.
+  // `monaco.languages.registerTokensProviderFactory` disposes any previous
+  // factory for the language and installs ours, so the basic-languages
+  // grammar can never reach the editor. We additionally call
+  // `setMonarchTokensProvider` synchronously so the very first paint uses
+  // our tokenizer (before the factory's `create()` is awaited).
+  //
+  // The effect re-runs whenever `validInstructions` changes so newly added
+  // instruction mnemonics are picked up by the keyword regex.
+  useEffect(() => {
+    if (!monaco) return undefined;
+    const instructionRegex = new RegExp(`\\b(${props.validInstructions})\\b`);
+    const tokenizer = {
+      tokenizer: {
+        root: [
+          [/^[ \t]*[a-zA-Z_][\w]*:/, 'type.identifier'], // label
+          [instructionRegex, 'keyword'],
+          [/\.[a-zA-Z_][\w]*/, 'strong'], // directives
+          [/[#,]/, 'delimiter'],
+          [/\br(?:\d{1,2})\b/, 'string'],
+          [/\d+/, 'number'],
+          [/".*?"/, 'regexp'],
+          [/;.*/, 'comment'],
+          [/[a-zA-Z_][\w]*/, 'identifier'],
+        ],
+      },
+    };
+    // Replace any previously-registered tokens-provider factory for `mips`.
+    // monaco-editor ships its own `mips` Monarch grammar via
+    // `basic-languages/mips/mips.contribution.js`, registered as an *async*
+    // factory. If we only call `setMonarchTokensProvider` (which performs
+    // a synchronous `register`), the stock factory's later async resolution
+    // overwrites our provider. `registerTokensProviderFactory` disposes any
+    // existing factory and installs ours, so the stock grammar can never
+    // reach the editor.
+    const factoryDisposable = monaco.languages.registerTokensProviderFactory(
+      'mips',
+      { create: () => tokenizer },
+    );
+    // Also install synchronously so the very first paint already uses our
+    // tokenizer before the factory's `create()` is awaited.
+    monaco.languages.setMonarchTokensProvider('mips', tokenizer);
+    return () => {
+      if (
+        factoryDisposable &&
+        typeof factoryDisposable.dispose === 'function'
+      ) {
+        factoryDisposable.dispose();
+      }
+    };
+  }, [monaco, props.validInstructions]);
 
   useEffect(() => {
     if (!monaco) {
@@ -238,7 +295,7 @@ const Code = (props) => {
     // Expose monaco and editor to window for testing purposes
     window.monaco = monaco;
     window.editor = editor;
-    
+
     setMonaco(monaco);
     setEditor(editor);
 
@@ -250,11 +307,11 @@ const Code = (props) => {
 
     // Ensure the required command is registered
     editor.addAction({
-      id: "editor.action.insertLineAfter",
-      label: "Insert Line After",
+      id: 'editor.action.insertLineAfter',
+      label: 'Insert Line After',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
       run: function (ed) {
-        ed.trigger("keyboard", "type", { text: "\n" });
+        ed.trigger('keyboard', 'type', { text: '\n' });
       },
     });
   };
@@ -281,7 +338,7 @@ const Code = (props) => {
     tabsize: 4,
     lineNumbersMinChars: 3,
     automaticLayout: true,
-    fontSize: props.fontSize,  // Set font size from props
+    fontSize: props.fontSize, // Set font size from props
   };
 
   // Hook to compute and set markers for warnings and errors.
@@ -328,14 +385,14 @@ const Code = (props) => {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
   return (
-        <MonacoEditor
-            language="mips"
-            value={props.code}
-            options={options}
-            onChange={props.onChangeValue}
-            theme={prefersDarkMode ? 'vs-dark' : 'vs-light'}
-            editorDidMount={editorDidMount}
-        />
+    <MonacoEditor
+      language="mips"
+      value={props.code}
+      options={options}
+      onChange={props.onChangeValue}
+      theme={prefersDarkMode ? 'vs-dark' : 'vs-light'}
+      editorDidMount={editorDidMount}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes #1723 for real this time.

### What the bug actually is

While a program is executing, **all** syntax highlighting in the Monaco editor disappears: instruction mnemonics, register names, comments, strings, directives — everything renders as plain black text. As soon as the simulator stops, the colours come back.

### Root cause

`Code.js` was calling `monaco.languages.setMonarchTokensProvider('mips', …)` directly in the component body, so the tokenizer was reinstalled on every render of `Code`. During Run All, the parent component re-renders many times per second (one per pipeline-state update), which means `setMonarchTokensProvider` was being called continuously throughout execution.

Each call to `setMonarchTokensProvider`:

1. invalidates the current tokenization for every line of the model, and
2. kicks off an async re-tokenization pass.

While that async pass is in flight Monaco renders the affected lines using the default token class (`mtk1`, `rgb(0, 0, 0)`). Because the calls are happening continuously the editor never gets a chance to finish a tokenization pass before the next reinstall arrives, so the editor stays "black" for the entire duration of the run.

I confirmed this by hooking `setMonarchTokensProvider` on the live preview build and counting calls per second:

```
after Load:        3 calls
during Run All:  ~30 calls/second
total over run:  171 calls
```

…and by sampling the editor DOM mid-run: every span on every `.code` line carried `class="mtk1"` and `getComputedStyle(span).color === "rgb(0, 0, 0)"`.

### The fix

Move the `setMonarchTokensProvider` call into a `useEffect` keyed on `props.validInstructions`. The instruction set never changes after the first worker hand-off (and across hot reloads in dev), so the provider is now installed exactly once for the lifetime of a session instead of dozens of times per second during execution.

### Why the previous commit on this branch did not fix the bug

I previously force-pushed a commit that lowered the alpha of the pipeline-stage decoration backgrounds in `style.css`, on the theory that the `.stageId` blue overlay was masking the blue keyword colour. That diagnosis was wrong: the underlying tokens were not actually blue during execution, they were already `mtk1`/black, so reducing the decoration alpha had no effect on the symptom the user reported. That commit has been replaced via force-push with the real fix in `Code.js`. No CSS changes are part of this PR anymore.

### Regression test

`src/test/webapp/syntax-highlighting-during-run.spec.js`:

- loads the default sample program,
- starts Run All,
- polls the editor DOM repeatedly during the run,
- on each poll, looks at every visible `.view-line` whose text contains a known mnemonic (`daddi`, `bne`, `nop`, `syscall`, …) and checks whether *every* `mtk*` span on that line is `rgb(0, 0, 0)`,
- fails if more than one such poll is observed during the run window.

Verified:

- ❌ RED against the buggy preview (`https://edumips64ci.z16.web.core.windows.net/1724/` before this push) — 33/33 polls during Run All saw fully-black mnemonic lines.
- ✅ GREEN against the fixed local build (`npm run build-dbg`).
- Full suite locally: 37 passed, 3 failed in `help-dialog.spec.js` (unrelated — the help docs are not in the local dist).

### Test plan

1. `npm run build-dbg`
2. Serve `out/web` on a localhost port
3. `PLAYWRIGHT_TARGET_URL='http://localhost:8080/' npx playwright test src/test/webapp/syntax-highlighting-during-run.spec.js`

Or just open the new preview URL once Azure rebuilds, click Load → Run All, and watch that the blue/green/red colours stay on while the simulator runs.
