### PR TITLE
ci: make Codecov checks resilient to unrelated CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,17 +120,40 @@ jobs:
           PLAYWRIGHT_TARGET_URL: 'http://localhost:8080'
         run: npx playwright test
 
+      # Upload Playwright traces, screenshots, and HTML report whenever the
+      # test step fails so the failure is diagnosable without rerunning. The
+      # most common failure mode (every test timing out on waitForSelector) is
+      # otherwise indistinguishable from a flake in raw logs.
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ github.run_id }}
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
       # Merge per-test coverage JSON files and produce an lcov report.
+      # Run regardless of test outcome: even with some failing tests we want to
+      # publish whatever coverage was collected, so the Codecov check reflects
+      # reality instead of "no upload" → "coverage dropped to 0".
       - name: Generate lcov coverage report
-        run: npx nyc report --reporter=lcov --reporter=text
+        if: always()
+        run: npx nyc report --reporter=lcov --reporter=text || true
 
       - name: Upload web UI coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           flags: web
           name: web-ui-coverage
+          # A transient Codecov upload error must not turn this job red on top
+          # of whatever the actual test outcome was.
+          fail_ci_if_error: false
 
   deploy-staging:
     name: Deploy web application to staging environment

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,24 @@
 coverage:
   range: "30...100"
-  
-status:
-  project:
-    default:
-      threshold: 1
+
+  status:
+    project:
+      default:
+        # Tolerate small fluctuations in total coverage.
+        threshold: 1
+        # A failed CI run (e.g. an unrelated Playwright timeout) should not also
+        # paint the Codecov check red on top — that produces two failures from
+        # one root cause. Keep Codecov out of the gating decision when CI is
+        # already failing or no upload arrived.
+        if_ci_failed: success
+        if_not_found: success
+    patch:
+      default:
+        # Patch coverage is informational: missing patch coverage often reflects
+        # tests living in a different language/flag (e.g. Playwright covers
+        # JS that unit tests do not), and a missing upload should not block.
+        if_ci_failed: success
+        if_not_found: success
 
 # The Swing UI is explicitly excluded from code coverage reports (see
 # docs/developer-guide.md). Main.java is the Swing entry point.
@@ -16,6 +30,7 @@ flags:
   java:
     paths:
       - src/main/java/
+    carryforward: true
   web:
     paths:
       - src/webapp/


### PR DESCRIPTION
## Problem

The `codecov/project` check has been failing on recent PRs whose product code is fine — for example #1680, #1713, #1720. Investigating the most recent occurrences, the Codecov failure is not actually about coverage:

A single Playwright bootstrap issue (every test timing out on `waitForSelector('#load-button')`) caused all of the following:

1. **`Run web tests with coverage`** → red (this is the real signal)
2. `Generate lcov coverage report` → never ran (skipped because the prior step failed)
3. `Upload web UI coverage to Codecov` → never ran
4. **`codecov/project`** → red, because no upload arrived and Codecov interprets a missing upload as "coverage dropped to 0"
5. **`codecov/patch`** → red, same reason

So one root cause is producing four red checks, and the two Codecov ones are not really telling us anything new — they are just amplifying the test failure. That makes the gate brittle: a flaky Playwright bootstrap or an upload glitch reads as "coverage regression."

## Changes

### `codecov.yml`
- `status.project.default` and `status.patch.default` set:
  - `if_ci_failed: success` — when CI is already red, don't add a redundant Codecov red on top.
  - `if_not_found: success` — a missing upload should not be treated as "coverage dropped to 0."
- `flags.java` gains `carryforward: true` to match `flags.web`, so the previous upload's coverage is reused when a job is skipped (e.g. docs-only PRs).

### `.github/workflows/ci.yml` (`web-ui-coverage` job)
- `Generate lcov coverage report` and `Upload web UI coverage to Codecov` now run with `if: always()`, so partial coverage is still published when some tests fail.
- The Codecov action is invoked with `fail_ci_if_error: false` so a transient upload error cannot turn the job red on top of the actual test outcome.
- On test failure, Playwright's `test-results/` and `playwright-report/` are uploaded as a workflow artifact (7-day retention), so failures of the "every test times out" kind become diagnosable from the run page without having to reproduce locally.

## Non-goals / what this does **not** change

- Coverage targets, thresholds, ignores, or flag scopes are unchanged.
- Codecov still computes project and patch coverage and still comments on the PR.
- The `Test web application` (against the deployed staging build) and `Run web tests with coverage` (against the local instrumented build) jobs are unchanged: failing tests still fail those checks.

The only behavioral difference is that Codecov no longer double-reports a CI failure as a coverage failure.

## Verification

- `codecov.yml` and `ci.yml` both parse as valid YAML.
- The new artifact upload uses `if-no-files-found: ignore`, so it is a no-op when the test step succeeded.
- Codecov configuration keys (`if_ci_failed`, `if_not_found`, `carryforward`) are documented in https://docs.codecov.com/docs/commit-status and https://docs.codecov.com/docs/flags.
