### PR TITLE
experimental: Focus Mode UI

### DIFF
--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -5,27 +5,40 @@ import Memory from './Memory';
 import Pipeline from './Pipeline';
 import Registers from './Registers';
 import Statistics from './Statistics';
-import Header from './Header';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import MuiAccordionSummary from '@mui/material/AccordionSummary';
-import Grid from '@mui/material/Grid';
 import ErrorList from './ErrorList';
 import StdOut from './StdOut';
 import InputDialog from './InputDialog';
-import Switch from '@mui/material/Switch';
+import HelpDialog from './HelpDialog';
+import CpuStatusDisplay from './CpuStatusDisplay';
+
 import Button from '@mui/material/Button';
-
-import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
-
-import { styled } from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import Typography from '@mui/material/Typography';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FastForwardIcon from '@mui/icons-material/FastForward';
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import PauseCircleIcon from '@mui/icons-material/PauseCircle';
+import StopCircleIcon from '@mui/icons-material/StopCircle';
+import UploadIcon from '@mui/icons-material/Upload';
+import DownloadIcon from '@mui/icons-material/Download';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import HelpIcon from '@mui/icons-material/Help';
+import SettingsIcon from '@mui/icons-material/Settings';
+import StorageIcon from '@mui/icons-material/Storage';
+import MemoryIcon from '@mui/icons-material/Memory';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import BarChartIcon from '@mui/icons-material/BarChart';
+
+import logoBright from '../static/logo.png';
+import logoDark from '../static/logo-dark.png';
 
 import SampleProgram from '../data/SampleProgram';
 
@@ -34,6 +47,8 @@ import Settings from './Settings';
 import CacheConfig from "./CacheConfig";
 import { useSetting } from '../settings/useSetting';
 import { SettingKey } from '../settings/SettingKey';
+
+import '../css/focus-mode.css';
 
 const Simulator = ({worker, initialState, appInsights}) => {
   // The amount of steps to run in multi-step executions.
@@ -467,24 +482,13 @@ const Simulator = ({worker, initialState, appInsights}) => {
     debouncedSyntaxCheck(code);
   };
 
-  const AccordionSummary = styled((props) => (
-    <MuiAccordionSummary
-      expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.8rem' }} />}
-      {...props}
-    />
-  ))(({ theme }) => ({
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .05)'
-        : 'rgba(227, 245, 254, 1)',
-    flexDirection: 'row-reverse',
-    '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-      transform: 'rotate(180deg)',
-    },
-    '& .MuiAccordionSummary-content': {
-      marginLeft: theme.spacing(1),
-    },
-  }));
+  // ---------------------------------------------------------------------------
+  // Focus Mode UI shell
+  // ---------------------------------------------------------------------------
+  // The editor is the main attraction. A slim activity rail on the left toggles
+  // an inspector drawer on the right (Pipeline / Registers / Memory). A bottom
+  // strip carries Stats and StdOut as tabs. Everything settings-related is
+  // tucked into a Preferences modal — out of the way until you ask for it.
 
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
@@ -493,188 +497,287 @@ const Simulator = ({worker, initialState, appInsights}) => {
       createTheme({
         palette: {
           mode: prefersDarkMode ? 'dark' : 'light',
+          primary: { main: '#007acc' },
         },
       }),
     [prefersDarkMode],
   );
 
+  // Active inspector panel (right drawer). null = collapsed.
+  const [inspector, setInspector] = React.useState('pipeline');
+  // Active bottom tab.
+  const [bottomTab, setBottomTab] = React.useState('stdout');
+  // Preferences dialog open state.
+  const [prefsOpen, setPrefsOpen] = React.useState(false);
+  // Help dialog open state.
+  const [helpOpen, setHelpOpen] = React.useState(false);
+
+  // Hidden file input for "Open code".
+  const fileInputRef = React.useRef(null);
+  const onPickFile = (e) => {
+    const f = e.target.files && e.target.files[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setCode(ev.target.result);
+    reader.readAsText(f);
+    e.target.value = '';
+  };
+
+  const inspectorPanels = {
+    pipeline: { label: 'Pipeline', body: <Pipeline pipeline={pipeline} /> },
+    registers: { label: 'Registers', body: <Registers {...registers} /> },
+    memory: { label: 'Memory', body: <Memory memory={memory} /> },
+  };
+
+  const RailBtn = ({ id, title, icon, alert }) => (
+    <Tooltip title={title} placement="right" arrow>
+      <button
+        className={inspector === id ? 'active' : ''}
+        onClick={() => setInspector((cur) => (cur === id ? null : id))}
+        aria-label={title}
+      >
+        {icon}
+        {alert && <span className="dot" />}
+      </button>
+    </Tooltip>
+  );
+
   return (
-    <>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <InputDialog
-          request={inputRequest}
-          onSubmit={submitInput}
-          onCancel={cancelInput}
-        />
-        <Header
-          onRunClick={clickRun}
-          runEnabled={simulatorRunning && !executing}
-          onStepClick={clickStep}
-          stepEnabled={simulatorRunning && !executing}
-          onLoadClick={loadCode}
-          loadEnabled={isValidProgram()}
-          onPauseClick={() => {
-            appInsights.trackEvent({name: "pause"})
-            setMustPause(true);
-          }}
-          pauseEnabled={executing}
-          onClearClick={clearCode}
-          onOpenClick={openCode}
-          onSaveClick={saveCode}
-          onStopClick={clickStop}
-          stopEnabled={simulatorRunning && !executing}
-          parsingErrors={parsingErrors}
-          version={worker.version}
-          status={status}
-          prefersDarkMode={prefersDarkMode}
-          multiStepCount={stepStride}
-        />
-        <Grid container id="main-grid" disableEqualOverflow spacing={0}>
-          <Grid id="left-panel" size={8}>
-            <Code
-              onChangeValue={onCodeChange}
-              code={code}
-              parsingErrors={parsingErrors}
-              parsedInstructions={parsedInstructions}
-              pipeline={pipeline}
-              running={simulatorRunning}
-              viMode={viMode}
-              fontSize={fontSize}
-              validInstructions={initialState.validInstructions}
-            />
-          </Grid>
-          <Grid size={4} id="right-panel" disableEqualOverflow>
-            <ErrorList
-              parsingErrors={parsingErrors}
-              AccordionSummary={AccordionSummary}
-            />
-            <Accordion 
-              expanded={expandedAccordions.stats} 
-              onChange={handleAccordionChange('stats')} 
-              disableGutters
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <InputDialog request={inputRequest} onSubmit={submitInput} onCancel={cancelInput} />
+      <HelpDialog open={helpOpen} handleClose={() => setHelpOpen(false)} ver={worker.version} />
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".asm,.txt,.s"
+        style={{ display: 'none' }}
+        onChange={onPickFile}
+      />
+
+      <div className="fm-root">
+        {/* ---------------------------------------------------------- title bar */}
+        <div className="fm-titlebar">
+          <span className="fm-brand">
+            <img src={prefersDarkMode ? logoDark : logoBright} alt="EduMIPS64" />
+            EduMIPS64 <span style={{ opacity: 0.6 }}>· Focus Mode</span>
+          </span>
+
+          <div className="fm-runbar">
+            <Tooltip title="Load the current code into the simulator" arrow>
+              <span>
+                <Button
+                  size="small"
+                  className="fm-primary"
+                  startIcon={<UploadIcon />}
+                  disabled={!isValidProgram() || status === 'RUNNING'}
+                  onClick={clickLoad}
+                >
+                  Load
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Single step" arrow>
+              <span>
+                <Button
+                  size="small"
+                  startIcon={<PlayArrowIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={() => clickStep(1)}
+                >
+                  Step
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title={`Run ${stepStride} steps`} arrow>
+              <span>
+                <Button
+                  size="small"
+                  startIcon={<FastForwardIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={() => clickStep(stepStride)}
+                >
+                  Multi
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Run until finished" arrow>
+              <span>
+                <Button
+                  size="small"
+                  startIcon={<PlayCircleIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={clickRun}
+                >
+                  Run
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Pause" arrow>
+              <span>
+                <IconButton size="small" disabled={!executing} onClick={() => {
+                  appInsights.trackEvent({ name: 'pause' });
+                  setMustPause(true);
+                }}>
+                  <PauseCircleIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Stop and reset CPU" arrow>
+              <span>
+                <IconButton size="small" disabled={!simulatorRunning || executing} onClick={clickStop}>
+                  <StopCircleIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            <span style={{ width: 8 }} />
+
+            <Tooltip title="Open code from file" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={() => fileInputRef.current?.click()}>
+                <UploadIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Save code to file" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={saveCode}>
+                <DownloadIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Clear editor" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={clearCode}>
+                <DeleteForeverIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+
+            <span style={{ width: 8 }} />
+
+            <Tooltip title="Preferences (cache, settings)" arrow>
+              <IconButton size="small" onClick={() => setPrefsOpen(true)}>
+                <SettingsIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Help" arrow>
+              <IconButton size="small" onClick={() => setHelpOpen(true)}>
+                <HelpIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </div>
+
+        {/* --------------------------------------------------- left activity rail */}
+        <div className="fm-rail">
+          <RailBtn
+            id="pipeline"
+            title="Pipeline"
+            icon={<TimelineIcon fontSize="small" />}
+            alert={accordionAlerts && accordionChanges.pipeline}
+          />
+          <RailBtn
+            id="registers"
+            title="Registers"
+            icon={<MemoryIcon fontSize="small" />}
+            alert={accordionAlerts && accordionChanges.registers}
+          />
+          <RailBtn
+            id="memory"
+            title="Memory"
+            icon={<StorageIcon fontSize="small" />}
+            alert={accordionAlerts && accordionChanges.memory}
+          />
+          <div className="fm-rail-spacer" />
+        </div>
+
+        {/* ------------------------------------------------------------- editor */}
+        <div className="fm-editor">
+          <ErrorList parsingErrors={parsingErrors} />
+          <Code
+            onChangeValue={onCodeChange}
+            code={code}
+            parsingErrors={parsingErrors}
+            parsedInstructions={parsedInstructions}
+            pipeline={pipeline}
+            running={simulatorRunning}
+            viMode={viMode}
+            fontSize={fontSize}
+            validInstructions={initialState.validInstructions}
+          />
+        </div>
+
+        {/* ---------------------------------------- bottom strip: stdout + stats */}
+        <div className="fm-bottom">
+          <div className="fm-bottom-tabs">
+            <button
+              className={bottomTab === 'stdout' ? 'active' : ''}
+              onClick={() => setBottomTab('stdout')}
             >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Stats
-                  {accordionAlerts && accordionChanges.stats && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Statistics {...stats} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.pipeline} 
-              onChange={handleAccordionChange('pipeline')} 
-              disableGutters
+              Output {accordionAlerts && accordionChanges.stdout && '•'}
+            </button>
+            <button
+              className={bottomTab === 'stats' ? 'active' : ''}
+              onClick={() => setBottomTab('stats')}
             >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Pipeline
-                  {accordionAlerts && accordionChanges.pipeline && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Pipeline pipeline={pipeline} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.registers} 
-              onChange={handleAccordionChange('registers')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Registers
-                  {accordionAlerts && accordionChanges.registers && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Registers {...registers} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.memory} 
-              onChange={handleAccordionChange('memory')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />} id="memory-accordion-summary">
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Memory
-                  {accordionAlerts && accordionChanges.memory && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Memory memory={memory} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.stdout} 
-              onChange={handleAccordionChange('stdout')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Standard Output
-                  {accordionAlerts && accordionChanges.stdout && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <StdOut stdout={stdout} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.cache} 
-              onChange={handleAccordionChange('cache')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: status === 'RUNNING' ? 'gray' : '#1976d2' }}>
-                  Cache Configuration
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <CacheConfig
-                  showTitle={false}
-                  onChange={setCacheConfig}
-                  status={status}
-                />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.settings} 
-              onChange={handleAccordionChange('settings')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  General Settings
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Settings
-                  viMode={viMode}
-                  setViMode={setViMode}
-                  fontSize={fontSize}
-                  setFontSize={setFontSize}
-                  accordionAlerts={accordionAlerts}
-                  setAccordionAlerts={setAccordionAlerts}
-                  forwarding={forwarding}
-                  setForwarding={setForwarding}
-                  stepStride={stepStride}
-                  setStepStride={setStepStride}
-                  executionDelayMs={executionDelayMs}
-                  setExecutionDelayMs={setExecutionDelayMs}
-                  status={status}
-                  showTitle={false}
-                />
-              </AccordionDetails>
-            </Accordion>
-          </Grid>
-        </Grid>
-      </ThemeProvider>
-    </>
+              <BarChartIcon style={{ fontSize: 12, verticalAlign: -2, marginRight: 4 }} />
+              Stats {accordionAlerts && accordionChanges.stats && '•'}
+            </button>
+            <span className="fm-spacer" />
+          </div>
+          <div className="fm-bottom-content">
+            {bottomTab === 'stdout' && <StdOut stdout={stdout} />}
+            {bottomTab === 'stats' && <Statistics {...stats} />}
+          </div>
+        </div>
+
+        {/* ----------------------------------------------------- right inspector */}
+        <div className={`fm-inspector ${inspector ? '' : 'collapsed'}`}>
+          {inspector && (
+            <>
+              <div className="fm-inspector-header">
+                {inspectorPanels[inspector].label}
+                <button className="fm-close" onClick={() => setInspector(null)} aria-label="Close panel">×</button>
+              </div>
+              <div className="fm-inspector-body">{inspectorPanels[inspector].body}</div>
+            </>
+          )}
+        </div>
+
+        {/* ------------------------------------------------------------ status bar */}
+        <div className="fm-statusbar">
+          <span className="fm-pill"><CpuStatusDisplay status={status} /></span>
+          <span>cycles: {stats.cycles ?? 0}</span>
+          <span>instr: {stats.instructions ?? 0}</span>
+          <span style={{ marginLeft: 'auto', opacity: 0.85 }}>
+            {worker.version}
+          </span>
+        </div>
+      </div>
+
+      {/* -------------------------------------------------- preferences dialog */}
+      <Dialog open={prefsOpen} onClose={() => setPrefsOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Preferences</DialogTitle>
+        <DialogContent dividers>
+          <h4 style={{ marginTop: 0 }}>Cache configuration</h4>
+          <CacheConfig showTitle={false} onChange={setCacheConfig} status={status} />
+          <h4 style={{ marginTop: 24 }}>General settings</h4>
+          <Settings
+            viMode={viMode}
+            setViMode={setViMode}
+            fontSize={fontSize}
+            setFontSize={setFontSize}
+            accordionAlerts={accordionAlerts}
+            setAccordionAlerts={setAccordionAlerts}
+            forwarding={forwarding}
+            setForwarding={setForwarding}
+            stepStride={stepStride}
+            setStepStride={setStepStride}
+            executionDelayMs={executionDelayMs}
+            setExecutionDelayMs={setExecutionDelayMs}
+            status={status}
+            showTitle={false}
+          />
+        </DialogContent>
+      </Dialog>
+    </ThemeProvider>
   );
 };
 

--- a/src/webapp/css/focus-mode.css
+++ b/src/webapp/css/focus-mode.css
@@ -1,0 +1,229 @@
+/* Focus Mode experimental UI — VS Code-style chrome around the editor. */
+
+.fm-root {
+  --fm-bg: #1e1e1e;
+  --fm-bg-2: #252526;
+  --fm-bg-3: #2d2d30;
+  --fm-border: #3c3c3c;
+  --fm-text: #cccccc;
+  --fm-text-dim: #858585;
+  --fm-accent: #007acc;
+  --fm-accent-2: #4ec9b0;
+  --fm-warn: #d7ba7d;
+  --fm-error: #f48771;
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  grid-template-rows: 36px 1fr auto 22px;
+  grid-template-areas:
+    "title title title"
+    "rail  editor  inspector"
+    "rail  bottom  inspector"
+    "status status status";
+  height: 100vh;
+  width: 100vw;
+  background: var(--fm-bg);
+  color: var(--fm-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+  .fm-root {
+    --fm-bg: #ffffff;
+    --fm-bg-2: #f3f3f3;
+    --fm-bg-3: #ececec;
+    --fm-border: #e0e0e0;
+    --fm-text: #1f1f1f;
+    --fm-text-dim: #6a6a6a;
+  }
+}
+
+.fm-titlebar {
+  grid-area: title;
+  background: var(--fm-bg-2);
+  border-bottom: 1px solid var(--fm-border);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  gap: 12px;
+  font-size: 12px;
+}
+
+.fm-titlebar .fm-brand {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.fm-titlebar .fm-brand img { height: 18px; }
+
+.fm-titlebar .fm-runbar {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.fm-titlebar .fm-runbar .MuiButton-root,
+.fm-titlebar .fm-runbar .MuiIconButton-root {
+  color: var(--fm-text);
+  text-transform: none;
+  font-size: 12px;
+  min-width: 0;
+  padding: 4px 8px;
+}
+
+.fm-titlebar .fm-runbar .MuiButton-root.fm-primary {
+  background: var(--fm-accent);
+  color: #fff;
+}
+
+.fm-rail {
+  grid-area: rail;
+  background: var(--fm-bg-2);
+  border-right: 1px solid var(--fm-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 6px;
+  gap: 2px;
+}
+
+.fm-rail button {
+  background: transparent;
+  border: none;
+  color: var(--fm-text-dim);
+  width: 48px;
+  height: 48px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: color 0.15s;
+}
+.fm-rail button:hover { color: var(--fm-text); }
+.fm-rail button.active {
+  color: var(--fm-text);
+  border-left-color: var(--fm-accent);
+}
+.fm-rail .dot {
+  position: absolute;
+  top: 8px; right: 8px;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--fm-accent);
+}
+
+.fm-rail .fm-rail-spacer { flex: 1; }
+
+.fm-editor {
+  grid-area: editor;
+  min-width: 0;
+  min-height: 0;
+  background: var(--fm-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.fm-editor > * { flex: 1; min-height: 0; }
+
+.fm-bottom {
+  grid-area: bottom;
+  background: var(--fm-bg-2);
+  border-top: 1px solid var(--fm-border);
+  max-height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+
+.fm-bottom-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--fm-border);
+  background: var(--fm-bg-3);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.fm-bottom-tabs button {
+  background: transparent;
+  border: none;
+  color: var(--fm-text-dim);
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+.fm-bottom-tabs button.active {
+  color: var(--fm-text);
+  border-bottom: 2px solid var(--fm-accent);
+}
+.fm-bottom-tabs .fm-spacer { flex: 1; }
+
+.fm-bottom-content {
+  overflow: auto;
+  padding: 8px 12px;
+}
+
+.fm-inspector {
+  grid-area: inspector;
+  width: 380px;
+  background: var(--fm-bg-2);
+  border-left: 1px solid var(--fm-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.fm-inspector.collapsed { display: none; }
+
+.fm-inspector-header {
+  padding: 10px 12px;
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--fm-text-dim);
+  border-bottom: 1px solid var(--fm-border);
+  display: flex;
+  align-items: center;
+}
+
+.fm-inspector-header .fm-close {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: var(--fm-text-dim);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.fm-inspector-body {
+  overflow: auto;
+  padding: 8px 12px;
+  flex: 1;
+}
+
+.fm-inspector-body table { width: 100%; }
+.fm-inspector-body td { padding: 2px 4px; }
+
+.fm-statusbar {
+  grid-area: status;
+  background: var(--fm-accent);
+  color: #fff;
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  gap: 14px;
+}
+
+.fm-statusbar .fm-pill {
+  background: rgba(255,255,255,0.15);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+/* Tone down stock MUI accordions used inside the inspector. */
+.fm-inspector .MuiAccordion-root { background: transparent; box-shadow: none; }
+.fm-inspector .MuiAccordionSummary-root { min-height: 36px; padding: 0; }


### PR DESCRIPTION
Experimental UI restyle. Editor-first VS Code-style shell: slim activity rail toggles a Pipeline/Registers/Memory inspector, bottom tabs hold Output/Stats, and a Preferences modal collects cache + general settings. No functional changes — every existing component is reused.