### PR TITLE
experimental: Dashboard Grid UI

### DIFF
--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -5,27 +5,34 @@ import Memory from './Memory';
 import Pipeline from './Pipeline';
 import Registers from './Registers';
 import Statistics from './Statistics';
-import Header from './Header';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import MuiAccordionSummary from '@mui/material/AccordionSummary';
-import Grid from '@mui/material/Grid';
 import ErrorList from './ErrorList';
 import StdOut from './StdOut';
 import InputDialog from './InputDialog';
-import Switch from '@mui/material/Switch';
+import HelpDialog from './HelpDialog';
+import CpuStatusDisplay from './CpuStatusDisplay';
+
 import Button from '@mui/material/Button';
-
-import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
-
-import { styled } from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Drawer from '@mui/material/Drawer';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import Typography from '@mui/material/Typography';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FastForwardIcon from '@mui/icons-material/FastForward';
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import PauseCircleIcon from '@mui/icons-material/PauseCircle';
+import StopCircleIcon from '@mui/icons-material/StopCircle';
+import UploadIcon from '@mui/icons-material/Upload';
+import DownloadIcon from '@mui/icons-material/Download';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import HelpIcon from '@mui/icons-material/Help';
+import TuneIcon from '@mui/icons-material/Tune';
+
+import logoBright from '../static/logo.png';
+import logoDark from '../static/logo-dark.png';
 
 import SampleProgram from '../data/SampleProgram';
 
@@ -34,6 +41,8 @@ import Settings from './Settings';
 import CacheConfig from "./CacheConfig";
 import { useSetting } from '../settings/useSetting';
 import { SettingKey } from '../settings/SettingKey';
+
+import '../css/dashboard-grid.css';
 
 const Simulator = ({worker, initialState, appInsights}) => {
   // The amount of steps to run in multi-step executions.
@@ -467,71 +476,168 @@ const Simulator = ({worker, initialState, appInsights}) => {
     debouncedSyntaxCheck(code);
   };
 
-  const AccordionSummary = styled((props) => (
-    <MuiAccordionSummary
-      expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.8rem' }} />}
-      {...props}
-    />
-  ))(({ theme }) => ({
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .05)'
-        : 'rgba(227, 245, 254, 1)',
-    flexDirection: 'row-reverse',
-    '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-      transform: 'rotate(180deg)',
-    },
-    '& .MuiAccordionSummary-content': {
-      marginLeft: theme.spacing(1),
-    },
-  }));
+    // ---------------------------------------------------------------------------
+  // Dashboard Grid UI
+  // ---------------------------------------------------------------------------
+  // Every panel is always visible. CSS Grid layout: editor + side panel +
+  // bottom inspector with sticky tabs. Cache + general settings live in a
+  // slide-in Preferences drawer reached from the topbar.
 
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
   const theme = React.useMemo(
-    () =>
-      createTheme({
-        palette: {
-          mode: prefersDarkMode ? 'dark' : 'light',
-        },
-      }),
+    () => createTheme({
+      palette: {
+        mode: prefersDarkMode ? 'dark' : 'light',
+        primary: { main: '#4f46e5' },
+      },
+    }),
     [prefersDarkMode],
   );
 
+  const [sideTab, setSideTab] = React.useState('pipeline');
+  const [bottomTab, setBottomTab] = React.useState('memory');
+  const [prefsOpen, setPrefsOpen] = React.useState(false);
+  const [helpOpen, setHelpOpen] = React.useState(false);
+
+  const fileInputRef = React.useRef(null);
+  const onPickFile = (e) => {
+    const f = e.target.files && e.target.files[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setCode(ev.target.result);
+    reader.readAsText(f);
+    e.target.value = '';
+  };
+
+  const tabBtn = (current, setCurrent, id, label, alert) => (
+    <button
+      key={id}
+      className={current === id ? 'active' : ''}
+      onClick={() => setCurrent(id)}
+    >
+      {label}{alert ? ' \u2022' : ''}
+    </button>
+  );
+
   return (
-    <>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <InputDialog
-          request={inputRequest}
-          onSubmit={submitInput}
-          onCancel={cancelInput}
-        />
-        <Header
-          onRunClick={clickRun}
-          runEnabled={simulatorRunning && !executing}
-          onStepClick={clickStep}
-          stepEnabled={simulatorRunning && !executing}
-          onLoadClick={loadCode}
-          loadEnabled={isValidProgram()}
-          onPauseClick={() => {
-            appInsights.trackEvent({name: "pause"})
-            setMustPause(true);
-          }}
-          pauseEnabled={executing}
-          onClearClick={clearCode}
-          onOpenClick={openCode}
-          onSaveClick={saveCode}
-          onStopClick={clickStop}
-          stopEnabled={simulatorRunning && !executing}
-          parsingErrors={parsingErrors}
-          version={worker.version}
-          status={status}
-          prefersDarkMode={prefersDarkMode}
-          multiStepCount={stepStride}
-        />
-        <Grid container id="main-grid" disableEqualOverflow spacing={0}>
-          <Grid id="left-panel" size={8}>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <InputDialog request={inputRequest} onSubmit={submitInput} onCancel={cancelInput} />
+      <HelpDialog open={helpOpen} handleClose={() => setHelpOpen(false)} ver={worker.version} />
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".asm,.txt,.s"
+        style={{ display: 'none' }}
+        onChange={onPickFile}
+      />
+
+      <div className="dg-root">
+        <div className="dg-topbar">
+          <span className="dg-brand">
+            <img src={prefersDarkMode ? logoDark : logoBright} alt="EduMIPS64" />
+            EduMIPS64
+            <span style={{ fontWeight: 400, fontSize: 11, color: 'var(--dg-text-dim)', marginLeft: 4 }}>
+              \u00b7 Dashboard
+            </span>
+          </span>
+
+          <div className="dg-runs">
+            <Tooltip title="Load code into the simulator" arrow>
+              <span>
+                <Button
+                  size="small"
+                  variant="contained"
+                  className="dg-load-btn"
+                  startIcon={<UploadIcon />}
+                  disabled={!isValidProgram() || status === 'RUNNING'}
+                  onClick={clickLoad}
+                >
+                  Load
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Single step" arrow>
+              <span>
+                <Button size="small" startIcon={<PlayArrowIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={() => clickStep(1)}>Step</Button>
+              </span>
+            </Tooltip>
+            <Tooltip title={`Run ${stepStride} steps`} arrow>
+              <span>
+                <Button size="small" startIcon={<FastForwardIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={() => clickStep(stepStride)}>Multi</Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Run until finished" arrow>
+              <span>
+                <Button size="small" startIcon={<PlayCircleIcon />}
+                  disabled={!simulatorRunning || executing}
+                  onClick={clickRun}>Run</Button>
+              </span>
+            </Tooltip>
+            <Tooltip title="Pause" arrow>
+              <span>
+                <IconButton size="small" disabled={!executing}
+                  onClick={() => { appInsights.trackEvent({ name: 'pause' }); setMustPause(true); }}>
+                  <PauseCircleIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Stop and reset CPU" arrow>
+              <span>
+                <IconButton size="small" disabled={!simulatorRunning || executing} onClick={clickStop}>
+                  <StopCircleIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </div>
+
+          <div className="dg-tail">
+            <span className="dg-status-chip"><CpuStatusDisplay status={status} /></span>
+            <Tooltip title="Open code from file" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={() => fileInputRef.current?.click()}>
+                <UploadIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Save code" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={saveCode}>
+                <DownloadIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Clear editor" arrow>
+              <IconButton size="small" disabled={status === 'RUNNING'} onClick={clearCode}>
+                <DeleteForeverIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Preferences" arrow>
+              <IconButton size="small" onClick={() => setPrefsOpen(true)}>
+                <TuneIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Help" arrow>
+              <IconButton size="small" onClick={() => setHelpOpen(true)}>
+                <HelpIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </div>
+
+        <div className="dg-card dg-editor">
+          <div className="dg-card-head">
+            <span>Code</span>
+            <span className="dg-tabs">
+              <span style={{fontSize:11, color:'var(--dg-text-dim)', textTransform:'none', letterSpacing:0, padding:'3px 6px'}}>
+                {parsingErrors && parsingErrors.length > 0 ? `${parsingErrors.length} issue(s)` : 'no issues'}
+              </span>
+            </span>
+          </div>
+          <div className="dg-card-body">
+            <ErrorList parsingErrors={parsingErrors} />
             <Code
               onChangeValue={onCodeChange}
               code={code}
@@ -543,138 +649,69 @@ const Simulator = ({worker, initialState, appInsights}) => {
               fontSize={fontSize}
               validInstructions={initialState.validInstructions}
             />
-          </Grid>
-          <Grid size={4} id="right-panel" disableEqualOverflow>
-            <ErrorList
-              parsingErrors={parsingErrors}
-              AccordionSummary={AccordionSummary}
+          </div>
+        </div>
+
+        <div className="dg-card dg-side">
+          <div className="dg-card-head">
+            <span>CPU State</span>
+            <div className="dg-tabs">
+              {tabBtn(sideTab, setSideTab, 'pipeline', 'Pipeline', accordionAlerts && accordionChanges.pipeline)}
+              {tabBtn(sideTab, setSideTab, 'registers', 'Registers', accordionAlerts && accordionChanges.registers)}
+            </div>
+          </div>
+          <div className="dg-card-body">
+            {sideTab === 'pipeline' && <Pipeline pipeline={pipeline} />}
+            {sideTab === 'registers' && <Registers {...registers} />}
+          </div>
+        </div>
+
+        <div className="dg-card dg-bottom">
+          <div className="dg-card-head">
+            <span>Inspect</span>
+            <div className="dg-tabs">
+              {tabBtn(bottomTab, setBottomTab, 'memory', 'Memory', accordionAlerts && accordionChanges.memory)}
+              {tabBtn(bottomTab, setBottomTab, 'stats', 'Stats', accordionAlerts && accordionChanges.stats)}
+              {tabBtn(bottomTab, setBottomTab, 'stdout', 'Output', accordionAlerts && accordionChanges.stdout)}
+            </div>
+          </div>
+          <div className="dg-card-body">
+            {bottomTab === 'memory' && <Memory memory={memory} />}
+            {bottomTab === 'stats' && <Statistics {...stats} />}
+            {bottomTab === 'stdout' && <StdOut stdout={stdout} />}
+          </div>
+        </div>
+      </div>
+
+      <Drawer anchor="right" open={prefsOpen} onClose={() => setPrefsOpen(false)}>
+        <div className="dg-drawer-content">
+          <h2 style={{ marginTop: 0 }}>Preferences</h2>
+          <div className="dg-drawer-section">
+            <h4>Cache configuration</h4>
+            <CacheConfig showTitle={false} onChange={setCacheConfig} status={status} />
+          </div>
+          <div className="dg-drawer-section">
+            <h4>Simulator settings</h4>
+            <Settings
+              viMode={viMode}
+              setViMode={setViMode}
+              fontSize={fontSize}
+              setFontSize={setFontSize}
+              accordionAlerts={accordionAlerts}
+              setAccordionAlerts={setAccordionAlerts}
+              forwarding={forwarding}
+              setForwarding={setForwarding}
+              stepStride={stepStride}
+              setStepStride={setStepStride}
+              executionDelayMs={executionDelayMs}
+              setExecutionDelayMs={setExecutionDelayMs}
+              status={status}
+              showTitle={false}
             />
-            <Accordion 
-              expanded={expandedAccordions.stats} 
-              onChange={handleAccordionChange('stats')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Stats
-                  {accordionAlerts && accordionChanges.stats && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Statistics {...stats} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.pipeline} 
-              onChange={handleAccordionChange('pipeline')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Pipeline
-                  {accordionAlerts && accordionChanges.pipeline && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Pipeline pipeline={pipeline} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.registers} 
-              onChange={handleAccordionChange('registers')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Registers
-                  {accordionAlerts && accordionChanges.registers && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Registers {...registers} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.memory} 
-              onChange={handleAccordionChange('memory')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />} id="memory-accordion-summary">
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Memory
-                  {accordionAlerts && accordionChanges.memory && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Memory memory={memory} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.stdout} 
-              onChange={handleAccordionChange('stdout')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  Standard Output
-                  {accordionAlerts && accordionChanges.stdout && <span className="accordion-change-indicator" />}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <StdOut stdout={stdout} />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.cache} 
-              onChange={handleAccordionChange('cache')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: status === 'RUNNING' ? 'gray' : '#1976d2' }}>
-                  Cache Configuration
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <CacheConfig
-                  showTitle={false}
-                  onChange={setCacheConfig}
-                  status={status}
-                />
-              </AccordionDetails>
-            </Accordion>
-            <Accordion 
-              expanded={expandedAccordions.settings} 
-              onChange={handleAccordionChange('settings')} 
-              disableGutters
-            >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 'bold', color: '#1976d2' }}>
-                  General Settings
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Settings
-                  viMode={viMode}
-                  setViMode={setViMode}
-                  fontSize={fontSize}
-                  setFontSize={setFontSize}
-                  accordionAlerts={accordionAlerts}
-                  setAccordionAlerts={setAccordionAlerts}
-                  forwarding={forwarding}
-                  setForwarding={setForwarding}
-                  stepStride={stepStride}
-                  setStepStride={setStepStride}
-                  executionDelayMs={executionDelayMs}
-                  setExecutionDelayMs={setExecutionDelayMs}
-                  status={status}
-                  showTitle={false}
-                />
-              </AccordionDetails>
-            </Accordion>
-          </Grid>
-        </Grid>
-      </ThemeProvider>
-    </>
+          </div>
+        </div>
+      </Drawer>
+    </ThemeProvider>
   );
 };
 

--- a/src/webapp/css/dashboard-grid.css
+++ b/src/webapp/css/dashboard-grid.css
@@ -1,0 +1,155 @@
+/* Dashboard Grid experimental UI — every panel always visible. */
+
+.dg-root {
+  --dg-bg: #f7f8fb;
+  --dg-card: #ffffff;
+  --dg-border: #e3e6ee;
+  --dg-text: #1f2533;
+  --dg-text-dim: #6b7280;
+  --dg-accent: #4f46e5;
+  --dg-accent-soft: #eef2ff;
+  --dg-good: #16a34a;
+  --dg-warn: #f59e0b;
+  --dg-danger: #dc2626;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  grid-template-rows: auto 1fr 1fr;
+  grid-template-areas:
+    "topbar    topbar"
+    "editor    side"
+    "bottom    side";
+  gap: 12px;
+  padding: 12px;
+  height: 100vh;
+  width: 100vw;
+  box-sizing: border-box;
+  background: var(--dg-bg);
+  color: var(--dg-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  .dg-root {
+    --dg-bg: #0f1117;
+    --dg-card: #181b24;
+    --dg-border: #262a36;
+    --dg-text: #e5e7eb;
+    --dg-text-dim: #9ca3af;
+    --dg-accent: #818cf8;
+    --dg-accent-soft: #1e1b4b;
+  }
+}
+
+.dg-card {
+  background: var(--dg-card);
+  border: 1px solid var(--dg-border);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.dg-card-head {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--dg-border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--dg-text-dim);
+}
+
+.dg-card-head .dg-tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+.dg-card-head .dg-tabs button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: inherit;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 3px 10px;
+  color: var(--dg-text-dim);
+  cursor: pointer;
+}
+.dg-card-head .dg-tabs button.active {
+  background: var(--dg-accent-soft);
+  color: var(--dg-accent);
+  border-color: var(--dg-accent);
+}
+
+.dg-card-body {
+  padding: 8px 12px;
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.dg-card-body table { width: 100%; }
+
+/* ----- top bar ----- */
+.dg-topbar {
+  grid-area: topbar;
+  background: var(--dg-card);
+  border: 1px solid var(--dg-border);
+  border-radius: 10px;
+  padding: 8px 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.dg-topbar .dg-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 16px;
+}
+.dg-topbar .dg-brand img { height: 22px; }
+.dg-topbar .dg-runs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 14px;
+}
+.dg-topbar .dg-tail {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.dg-topbar .MuiButton-root { text-transform: none; }
+.dg-topbar .dg-load-btn { background: var(--dg-accent); color: #fff; }
+.dg-topbar .dg-load-btn:hover { background: #3730a3; }
+
+.dg-status-chip {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--dg-accent-soft);
+  color: var(--dg-accent);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* ----- main areas ----- */
+.dg-editor { grid-area: editor; }
+.dg-editor .dg-card-body { padding: 0; }
+.dg-editor .dg-card-body > * { height: 100%; }
+
+.dg-side { grid-area: side; }
+.dg-bottom { grid-area: bottom; }
+
+/* drawer */
+.dg-drawer-content { padding: 16px 24px; min-width: 360px; }
+.dg-drawer-content h4 { margin: 0 0 8px; font-size: 13px; color: var(--dg-text-dim); text-transform: uppercase; letter-spacing: .8px; }
+.dg-drawer-section { padding: 14px 0; border-bottom: 1px solid var(--dg-border); }
+.dg-drawer-section:last-child { border-bottom: none; }


### PR DESCRIPTION
Experimental UI restyle. Always-visible CSS-grid layout: editor + tabbed side panel (Pipeline/Registers) + tabbed bottom inspector (Memory/Stats/Output). Settings move to a slide-in Preferences drawer. Drops the right-hand accordion stack.