### PR TITLE
Exclude MIPS64 ISA PDF from the JAR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,8 +224,12 @@ tasks.register("htmlDocs") {
 
 tasks.register<Copy>("copyHelp") {
     from("docs/") {
-        exclude("**/src/**", "**/design/**", "**/*.py",  "**/*.pyc", 
-            "**/*.md", "**/.buildinfo", "**/objects.inv", "**/*.txt", "**/__pycache__/**")
+        exclude("**/src/**", "**/design/**", "**/*.py",  "**/*.pyc",
+            "**/*.md", "**/.buildinfo", "**/objects.inv", "**/*.txt", "**/__pycache__/**",
+            // The MIPS64 ISA reference PDF is large (~5.6 MB) and is not referenced
+            // by JavaHelp or any in-app component; ship it via the project website
+            // instead of embedding it in every JAR.
+            "**/*.pdf")
     }
     into(docsDir)
     copyHelpTaskNames.forEach { dependsOn(it) }


### PR DESCRIPTION
`docs/MIPS64ISA.pdf` is a 5.6 MB MIPS64 architecture reference manual that gets bundled into the JAR by the `copyHelp` task, but is **not referenced** by JavaHelp, the Swing UI, the CLI, or any other in-app component (verified by grep over both Java sources and `docs/user/{en,it,zh}/src/`).

Adding `**/*.pdf` to the existing `copyHelp` exclude list shrinks the desktop JAR from **8.6 MB → 3.6 MB** (~58% reduction) with no user-visible loss of functionality.

### Verification

```
$ ls -la out/edumips64-1.3.0.jar
-rw-rw-r-- 1 andrea andrea 3793343 ... out/edumips64-1.3.0.jar

$ unzip -l out/edumips64-1.3.0.jar | grep -i '\.pdf' || echo 'no pdf'
no pdf

$ echo exit | java -jar out/edumips64-1.3.0.jar --headless --no-banner
edumips64 [READY] > Goodbye!

$ ./gradlew test
BUILD SUCCESSFUL
```

The PDF remains in the source tree (`docs/MIPS64ISA.pdf`) and can still be shipped separately via the project website if desired.