### PR TITLE
Downgrade Python 3.14 -> 3.12 to fix snap build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -34,11 +34,11 @@ jobs:
           distribution: 'microsoft'
           cache: 'gradle'
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.12
         id: setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Configure Python path for Gradle
         run: |

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -26,11 +26,11 @@ jobs:
           distribution: 'microsoft'
           cache: 'gradle'
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.12
         id: setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Configure Python path for Gradle
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ python {
     }
     scope = VIRTUALENV
     requirements.file = "docs/requirements.txt"
-    minPythonVersion = "3.14"
+    minPythonVersion = "3.12"
 }
 
 application {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,30 +34,12 @@ parts:
       fi
 
       craftctl default
-      # Point the ru.vyarus.use-python Gradle plugin at Python 3.14 (installed
-      # from deadsnakes in override-pull), since the system python3 on core24 is 3.12.
-      export ORG_GRADLE_PROJECT_pythonPath=/usr/local/bin
       mkdir -p "$CRAFT_PART_INSTALL"/jar
       bash gradlew --no-daemon "$@" jar && \
         ls -ld out/edumips64-*.jar && \
         mv out/edumips64-*.jar "$CRAFT_PART_INSTALL"/jar/edumips64.jar && \
         ls $CRAFT_PART_INSTALL/jar/*.jar -ld
     source: .
-    # Core24 (Ubuntu 24.04) only ships Python 3.12 in its default repos, so Python 3.14
-    # (required by the Gradle build for the documentation) is installed from the
-    # deadsnakes PPA in override-pull below.
-    override-pull: |
-      craftctl default
-      apt-get update
-      apt-get install -y software-properties-common
-      add-apt-repository -y ppa:deadsnakes/ppa
-      apt-get update
-      apt-get install -y python3.14-dev python3.14-venv
-      # The ru.vyarus.use-python Gradle plugin looks for a `python`/`python3`
-      # binary in pythonPath; deadsnakes only ships `python3.14`, so expose
-      # it under the conventional names in /usr/local/bin.
-      ln -sf /usr/bin/python3.14 /usr/local/bin/python3
-      ln -sf /usr/bin/python3.14 /usr/local/bin/python
     build-packages:
       - git
       - pkg-config
@@ -65,6 +47,8 @@ parts:
       - ca-certificates-java
       - ca-certificates
       - python3-pip
+      - python3-venv
+      - python3-dev
       # Needed to build pillow, a rst2pdf dependency.
       - zlib1g-dev
       - libjpeg-dev


### PR DESCRIPTION
## Why

The snap build has been failing repeatedly with:

```
Err:5 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble InRelease
  Could not connect to ppa.launchpadcontent.net:443 (185.125.190.80), connection timed out
```

This is *not* a transient outage — it has reproduced across multiple reruns. There are no GitHub network settings to fix it: the connection is failing from inside the snap build's LXD container, not the runner itself (the runner happily downloads from `archive.ubuntu.com` in the same job).

The reason we depend on deadsnakes at all is that `build.gradle.kts` declares `minPythonVersion = "3.14"`, while `core24` (Ubuntu 24.04, the snap base) only ships Python 3.12. None of our docs dependencies actually require 3.14 — `sphinx 9.1.0` and `rst2pdf 0.105` only need >= 3.10. The floor crept up over time (3.8 → 3.11 → 3.12 → 3.14) without a real driver.

## What

- `build.gradle.kts`: `minPythonVersion = "3.14"` → `"3.12"`
- `snapcraft.yaml`: drop the entire `override-pull` block (deadsnakes setup) and the `ORG_GRADLE_PROJECT_pythonPath` export; use core24's stock `python3` (3.12) via `python3-pip`/`-venv`/`-dev` build-packages
- `.github/workflows/build-desktop.yml` and `build-web.yml`: `actions/setup-python` 3.14 → 3.12 (consistency with the `minPythonVersion` floor)

This removes Launchpad as a single point of failure for the snap build entirely.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>