### PR TITLE
Release pipeline fixes: include zh PDF; fix Electron 'Cannot GET /'

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -21,17 +21,17 @@ jobs:
             platform: linux
             arch: x64
             artifact-name: Electron Linux x64
-            artifact-path: out/WebEduMips64-linux-x64
+            artifact-path: electron/dist/WebEduMips64-linux-x64
           - os: macos-latest
             platform: darwin
             arch: arm64
             artifact-name: Electron macOS ARM64
-            artifact-path: out/WebEduMips64-darwin-arm64
+            artifact-path: electron/dist/WebEduMips64-darwin-arm64
           - os: windows-latest
             platform: win32
             arch: x64
             artifact-name: Electron Windows x64
-            artifact-path: out/WebEduMips64-win32-x64
+            artifact-path: electron/dist/WebEduMips64-win32-x64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,16 +56,21 @@ jobs:
         working-directory: electron
         shell: bash
         run: |
-          rm -rf ../out/WebEduMips64-${{ matrix.platform }}-${{ matrix.arch }}
+          # Note: @electron/packager auto-ignores its own --out directory
+          # within the source tree, so we MUST NOT use ../out here — that
+          # would strip the out/web/ web bundle from the packaged app and
+          # leave the express server with nothing to serve. Use a sibling
+          # output directory (electron/dist) instead.
+          rm -rf dist/WebEduMips64-${{ matrix.platform }}-${{ matrix.arch }}
 
           # Copy index.js to root directory (required by @electron/packager)
           cp index.js ..
 
           # Build the Electron app
           if [ "${{ matrix.platform }}" = "linux" ]; then
-            npx @electron/packager ../ WebEduMips64 --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --out ../out
+            npx @electron/packager ../ WebEduMips64 --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --out dist
           else
-            npx @electron/packager ../ WebEduMips64 --asar --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --out ../out
+            npx @electron/packager ../ WebEduMips64 --asar --platform=${{ matrix.platform }} --arch=${{ matrix.arch }} --out dist
           fi
 
           rm ../index.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,7 @@ jobs:
           # PDF manuals
           cp "release-artifacts/English manual (PDF)/EduMIPS64.pdf" staged/EduMIPS64-manual-en.pdf
           cp "release-artifacts/Italian manual (PDF)/EduMIPS64.pdf" staged/EduMIPS64-manual-it.pdf
+          cp "release-artifacts/Chinese manual (PDF)/EduMIPS64.pdf" staged/EduMIPS64-manual-zh.pdf
 
           # MSI
           cp release-artifacts/MSI/EduMIPS64-*.msi staged/


### PR DESCRIPTION
Two small, unrelated release-pipeline bugs.

## 1. Chinese PDF missing from GitHub releases

`build-desktop.yml` builds and uploads all three PDF manuals (en / it / zh), but `release.yml` only stages the English and Italian ones for the release. The zh PDF therefore never makes it into the release page even though it builds successfully.

Adds the missing `cp` for `EduMIPS64-manual-zh.pdf`.

## 2. Packaged Electron app fails with 'Cannot GET /'

When you launch the released Linux Electron app today:

```
$ ./WebEduMips64
Server express started at http://localhost:8081
```

…and the window shows nothing but `Cannot GET /`.

**Root cause:** `@electron/packager` [auto-adds `--out` to its ignore list](https://electron.github.io/packager/main/interfaces/Options.html#out) when the output directory is inside the source tree. The workflow ran:

```
npx @electron/packager ../ WebEduMips64 --out ../out
```

Source = repo root, `--out` = `<repo>/out`. So packager stripped the **entire** `out/` directory from the asar — including `out/web/`, the web bundle that was downloaded into `out/web/` by the preceding `download-artifact` step. The express server inside the packaged app then served `__dirname/../out/web` and got nothing back.

Verified by listing the asar of the v1.4.0 Linux build: 53k files inside, but `out/web/` and `out/web/index.html` are absent.

**Fix:** write the packager output to `electron/dist/` instead — outside `out/` — matching the convention already used by `gen_electron_app_{linux,macos,win32}*` scripts. Updated `artifact-path` in the build matrix accordingly.

The local `gen_electron_app_*.sh` scripts already used `--out dist` and were unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>