### PR TITLE
ci: auto-deploy previews for Copilot-triggered PRs

### DIFF
--- a/.github/workflows/pr-reports.yml
+++ b/.github/workflows/pr-reports.yml
@@ -57,8 +57,9 @@ jobs:
       # controllable from PR content.
       #
       #   staging-dependabot : no manual approval required. Used for trusted
-      #                        maintainers and automation bots so their PRs get
-      #                        a preview without a human gate.
+      #                        maintainers and automation bots (Dependabot,
+      #                        Renovate, the Copilot coding agent) so their PRs
+      #                        get a preview without a human gate.
       #   Staging            : approval-gated environment. Used for everyone
       #                        else, including PRs from forks, so a maintainer
       #                        must approve before secrets are used to deploy.
@@ -71,8 +72,18 @@ jobs:
         env:
           ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
         run: |
+          # Actor logins are matched case-insensitively because GitHub may
+          # report e.g. the Copilot coding agent as "Copilot" rather than
+          # "copilot". Quote the "[bot]" entries so the brackets are treated
+          # literally and not as a glob character class.
+          shopt -s nocasematch
           maintainers=(lupino3)
-          bots=(dependabot dependabot[bot] renovate renovate[bot] copilot copilot[bot])
+          bots=(
+            dependabot "dependabot[bot]"
+            renovate "renovate[bot]"
+            copilot "copilot[bot]"
+            copilot-swe-agent "copilot-swe-agent[bot]"
+          )
 
           environment=Staging
           for actor in "${maintainers[@]}" "${bots[@]}"; do


### PR DESCRIPTION
## Problem

PR preview deploys (`pr-reports.yml`, introduced in #1800) pick the deployment environment from the CI Build's **triggering actor**:

- `staging-dependabot` — no manual approval, for trusted maintainers/bots.
- `Staging` — approval-gated, for everyone else (incl. forks).

The Copilot coding agent triggers CI as the actor **`Copilot`** (capitalised), but the allowlist only contained the lowercase `copilot`/`copilot[bot]`. Because the bash `[[ ... == ... ]]` comparison is **case-sensitive**, `Copilot` never matched, so agent-authored PRs fell through to the approval-gated `Staging` environment and sat in `action_required`, never deploying a preview.

Observed on #1788: bot-triggered runs showed `status=action_required`, while the same PR deployed fine when a maintainer pushed.

## Fix

- Match actor logins **case-insensitively** (`shopt -s nocasematch`).
- Add the `copilot-swe-agent` / `copilot-swe-agent[bot]` login variants.
- Quote the `[bot]` entries so the brackets match literally rather than as a glob character class.

The Copilot coding agent is now treated as trusted automation (like Dependabot/Renovate) and its PRs auto-deploy to staging. **Untrusted actors — including all forks — still route to the approval-gated environment.**

## Validation

Tested the selection logic against representative actors:

| Actor | Environment |
|-------|-------------|
| `Copilot`, `copilot`, `copilot[bot]` | `staging-dependabot` (auto) |
| `copilot-swe-agent`, `Copilot-SWE-Agent[bot]` | `staging-dependabot` (auto) |
| `lupino3`, `dependabot`, `renovate[bot]` | `staging-dependabot` (auto) |
| `davidepatti`, `evilfork` (untrusted) | `Staging` (approval-gated) |

YAML validated with PyYAML.