### PR TITLE
Automerge GitHub Actions Renovate updates when CI is green

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,12 @@
       matchUpdateTypes: ["minor"],
       automerge: true,
     },
+    // Automerge GitHub Actions updates (all update types) once CI is green.
+    // Renovate enables merge only after required status checks pass.
+    {
+      matchManagers: ["github-actions"],
+      automerge: true,
+    },
     // Group React-related dependencies together
     {
       groupName: "React packages",


### PR DESCRIPTION
## Summary

Configure Renovate to **automerge GitHub Actions updates** once CI is green.

Adds a `packageRule` matching the `github-actions` manager with `automerge: true`. Renovate only enables the merge after the branch's required status checks pass, so green CI is a precondition — and `config:recommended` (already extended) enables platform automerge via GitHub's native auto-merge.

```json5
{
  matchManagers: ["github-actions"],
  automerge: true,
}
```

### Why
Action version bumps (e.g. `actions/checkout`, `actions/github-script`) are low-risk and were previously requiring manual review/merge (see #1809, #1810). This removes that toil while keeping the CI gate.

### Scope
- Applies to all update types for the `github-actions` manager (including majors, which is how these actions version — v4→v6, v7→v9).
- No change to existing devDependency / patch / test-dependency / Gradle-plugin automerge rules.
- Validated with `renovate-config-validator` (passes).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
