### PR TITLE
docs: add Unreleased changelog section for #1736, #1804, #1713

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## 1.4.1 (TBD)
 
+### Added
+- Web UI now persists the editor's program contents in the browser's local
+  storage, so your code survives page reloads. Also added a new "Restore default
+  sample" button to reset the editor back to the bundled sample program.
+  (@Copilot, PR #1736)
+
 ### Fixed
+- Web UI Cache Configuration panel no longer loses focus after each keystroke,
+  making input fields much easier to edit. (@davidepatti, PR #1804)
 
 ### Changed
+- Web UI now shows the Stats, Pipeline and Registers panels expanded by default
+  on a first visit, so the simulator's core views are visible immediately.
+  Returning users keep their last layout preference. (@Copilot, Issue #1697)
 
 ## 1.4.0 (03/05/2026) - WalkOfLife
 


### PR DESCRIPTION
Add Unreleased section to CHANGELOG.md documenting three user-facing changes merged since 1.4.0:

- **Web UI local storage persistence** (PR #1736): Editor code is now saved to browser local storage and persists across page reloads. Added a new "Restore default sample" button to reset to the bundled sample program.

- **Cache Configuration panel focus fix** (PR #1804): Fixed a bug where input fields in the Cache Configuration panel lost focus after each keystroke, making them difficult to edit.

- **Default expanded panels layout** (PR #1713, closes Issue #1697): Web UI now shows Stats, Pipeline, and Registers panels expanded by default on first visit, so simulator core views are immediately visible. Returning users retain their last layout preference.

Ready for review.