### PR TITLE
fix: pin transitive uuid to >= 11.1.1 (CVE-2026-41907) (closes #1808)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10766,14 +10766,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "webpack-bundle-analyzer": "5.3.0",
     "webpack-cli": "7.0.3",
     "webpack-dev-server": "5.2.4"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Add a top-level npm override so transitive dev/build-time `uuid` resolves to the patched 11.1.1 line.
- Regenerate `package-lock.json`; no parent dev dependency upgrades needed.
- `uuid` remains used only through build/test tooling paths (`nyc`/`istanbul-lib-processinfo` and `webpack-dev-server`/`sockjs`).

## Verification
- Before: `npm ls uuid` reported `uuid@8.3.2` via `nyc -> istanbul-lib-processinfo` and `webpack-dev-server -> sockjs`.
- After: `npm ls uuid` reports `uuid@11.1.1 overridden` for `nyc -> istanbul-lib-processinfo` and `uuid@11.1.1 deduped` for `webpack-dev-server -> sockjs`.
- `npm run build` succeeds (webpack compiled with existing asset-size warnings).
- Local Playwright execution was attempted, but this host cannot install/run the required browser because Playwright does not support chromium on ubuntu26.04-x64; CI should run this on its supported runner.

Closes #1808