### PR TITLE
fix(web): resolve react-hooks/exhaustive-deps in Code.js and CacheConfig.js (closes #1717)

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -8,4 +8,3 @@
 ## Learnings
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
-- 2026-06-05T16:05:59+02:00: React hook effects in Code.js use refs for Monaco/Vim disposables so exhaustive-deps stays truthful without eslint-disable comments.

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -8,3 +8,4 @@
 ## Learnings
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
+- 2026-06-05T16:05:59+02:00: React hook effects in Code.js use refs for Monaco/Vim disposables so exhaustive-deps stays truthful without eslint-disable comments.

--- a/src/test/webapp/exhaustive-deps-regressions.spec.js
+++ b/src/test/webapp/exhaustive-deps-regressions.spec.js
@@ -1,0 +1,216 @@
+const { test, expect } = require('./fixtures');
+const {
+  targetUri,
+  removeOverlay,
+  waitForPageReady,
+  loadProgram,
+  runToCompletion,
+} = require('./test-utils');
+
+const STORAGE_PREFIX = 'edumips64:v1:';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(targetUri);
+  await page.evaluate((prefix) => {
+    const keysToRemove = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith(prefix)) {
+        keysToRemove.push(k);
+      }
+    }
+    keysToRemove.forEach((k) => window.localStorage.removeItem(k));
+  }, STORAGE_PREFIX);
+});
+
+async function setEditorContent(page, code) {
+  await removeOverlay(page);
+  const inputArea = page.locator('.monaco-editor textarea.inputarea');
+  await inputArea.click({ force: true });
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.insertText(code);
+}
+
+async function openSettingsAccordion(page) {
+  const summary = page.getByRole('button', { name: /General Settings/ });
+  await summary.waitFor({ state: 'visible' });
+  if ((await summary.getAttribute('aria-expanded')) !== 'true') {
+    await summary.click();
+  }
+  await expect(summary).toHaveAttribute('aria-expanded', 'true');
+}
+
+async function expandCacheConfig(page) {
+  const cacheAccordionSummary = page.getByRole('button', {
+    name: /Cache Configuration/,
+  });
+  await cacheAccordionSummary.waitFor({ state: 'visible' });
+  if ((await cacheAccordionSummary.getAttribute('aria-expanded')) !== 'true') {
+    await cacheAccordionSummary.click();
+  }
+  await expect(cacheAccordionSummary).toHaveAttribute('aria-expanded', 'true');
+}
+
+async function setCacheConfig(page, cacheType, config) {
+  await expandCacheConfig(page);
+  const cacheSection = page.locator(`text=${cacheType}`).locator('..');
+
+  if (config.size !== undefined) {
+    await cacheSection
+      .locator('input[type="number"]')
+      .nth(0)
+      .fill(String(config.size));
+  }
+  if (config.blockSize !== undefined) {
+    await cacheSection
+      .locator('input[type="number"]')
+      .nth(1)
+      .fill(String(config.blockSize));
+  }
+  if (config.associativity !== undefined) {
+    await cacheSection
+      .locator('input[type="number"]')
+      .nth(2)
+      .fill(String(config.associativity));
+  }
+}
+
+async function getCacheStats(page) {
+  const l1iReadsCell = page.locator('#stat-l1i-reads');
+  await expect(l1iReadsCell).not.toHaveText('0', { timeout: 10000 });
+
+  return {
+    l1iMisses: parseInt(
+      (await page.locator('#stat-l1i-misses').textContent()) || '0',
+      10,
+    ),
+    l1dWriteMisses: parseInt(
+      (await page.locator('#stat-l1d-write-misses').textContent()) || '0',
+      10,
+    ),
+  };
+}
+
+test('syntax errors update Monaco error markers', async ({ page }) => {
+  await waitForPageReady(page);
+
+  await setEditorContent(page, '.code\nTHIS_IS_NOT_AN_INSTRUCTION r1\n');
+
+  const marker = await page.waitForFunction(
+    () => {
+      const model = window.editor && window.editor.getModel();
+      if (!window.monaco || !model) return null;
+      return window.monaco.editor
+        .getModelMarkers({ resource: model.uri })
+        .find(
+          (m) =>
+            m.source === 'EduMIPS64' &&
+            m.severity === window.monaco.MarkerSeverity.Error,
+        );
+    },
+    null,
+    { timeout: 10000 },
+  );
+
+  expect(await marker.jsonValue()).toMatchObject({
+    startLineNumber: 2,
+    source: 'EduMIPS64',
+  });
+});
+
+test('Vim mode can be enabled and disabled after the editor mounts', async ({
+  page,
+}) => {
+  await waitForPageReady(page);
+  await setEditorContent(page, '.code\nSYSCALL 0\n');
+  await openSettingsAccordion(page);
+
+  const viModeSwitch = page.getByLabel('Editor Vi Mode');
+  await expect(viModeSwitch).not.toBeChecked();
+  await viModeSwitch.click();
+  await expect(viModeSwitch).toBeChecked();
+
+  await page.evaluate(() => {
+    window.editor.setPosition({ lineNumber: 1, column: 1 });
+    window.editor.focus();
+  });
+  await page.keyboard.press('j');
+
+  await expect
+    .poll(() => page.evaluate(() => window.editor.getPosition().lineNumber))
+    .toBe(2);
+  await expect
+    .poll(() => page.evaluate(() => window.editor.getValue()))
+    .toBe('.code\nSYSCALL 0\n');
+
+  await viModeSwitch.click();
+  await expect(viModeSwitch).not.toBeChecked();
+  await page.evaluate(() => {
+    window.editor.setPosition({ lineNumber: 1, column: 1 });
+    window.editor.focus();
+  });
+  await page.keyboard.press('j');
+
+  await expect
+    .poll(() => page.evaluate(() => window.editor.getValue()))
+    .toBe('j.code\nSYSCALL 0\n');
+});
+
+test('cache config changes synchronize before the next run', async ({
+  page,
+}) => {
+  await waitForPageReady(page);
+
+  const program = `.data
+arr: .space 64
+
+.code
+DADDI r10, r0, arr
+DADDI r1, r0, 1
+SD r1, 0(r10)
+SD r1, 8(r10)
+SD r1, 16(r10)
+SD r1, 24(r10)
+SD r1, 32(r10)
+SD r1, 40(r10)
+SD r1, 48(r10)
+SD r1, 56(r10)
+SYSCALL 0
+`;
+
+  await setCacheConfig(page, 'L1 Instruction Cache', {
+    size: 1024,
+    blockSize: 8,
+    associativity: 1,
+  });
+  await setCacheConfig(page, 'L1 Data Cache', {
+    size: 1024,
+    blockSize: 8,
+    associativity: 1,
+  });
+  await loadProgram(page, program);
+  await runToCompletion(page);
+  const smallBlockStats = await getCacheStats(page);
+
+  await setCacheConfig(page, 'L1 Instruction Cache', {
+    size: 1024,
+    blockSize: 64,
+    associativity: 1,
+  });
+  await setCacheConfig(page, 'L1 Data Cache', {
+    size: 1024,
+    blockSize: 64,
+    associativity: 1,
+  });
+  await loadProgram(page, program);
+  await runToCompletion(page);
+  const largeBlockStats = await getCacheStats(page);
+
+  expect(largeBlockStats.l1iMisses).toBeLessThanOrEqual(
+    smallBlockStats.l1iMisses,
+  );
+  expect(largeBlockStats.l1dWriteMisses).toBeLessThan(
+    smallBlockStats.l1dWriteMisses,
+  );
+});

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { initVimMode } from 'monaco-vim';
 
 // new

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { initVimMode } from 'monaco-vim';
 
 // new
@@ -23,15 +23,14 @@ monacoEditor.languages.register({ id: 'mips' });
 const Code = (props) => {
   const [monaco, setMonaco] = useState(null);
   const [editor, setEditor] = useState(null);
-  const [vimInstance, setVimInstance] = useState(null); // new state for Vim instance
-  // IDisposable to clean up the hover provider.
-  const [hoverDisposable, setHoverCleanup] = useState(null);
+  const vimInstanceRef = useRef(null);
+  const hoverDisposableRef = useRef(null);
 
   // Decorations (used for CPU stage indication).
-  const [decorations, setDecorations] = useState([]);
+  const decorationsRef = useRef([]);
 
   // Maps line of code to CPU stage.
-  const [stageMap, setStageMap] = useState(new Map());
+  const [stageMap, setStageMap] = useState(() => new Map());
 
   // Install our MIPS syntax highlighting provider.
   //
@@ -110,12 +109,15 @@ const Code = (props) => {
   }, [monaco, props.validInstructions]);
 
   useEffect(() => {
-    if (!monaco) {
+    if (!monaco || !editor) {
       return;
     }
-    if (!props.running && decorations) {
-      const newDecorations = editor.deltaDecorations(decorations, []);
-      setDecorations(decorations);
+    if (!props.running) {
+      decorationsRef.current = editor.deltaDecorations(
+        decorationsRef.current,
+        [],
+      );
+      setStageMap(new Map());
       return;
     }
 
@@ -222,12 +224,11 @@ const Code = (props) => {
     setStageMap(newStageMap);
     console.log('decorations');
     console.log(newDecorations);
-    const appliedDecorations = editor.deltaDecorations(
-      decorations,
+    decorationsRef.current = editor.deltaDecorations(
+      decorationsRef.current,
       newDecorations,
     );
-    setDecorations(appliedDecorations);
-  }, [props.pipeline, props.running, monaco]);
+  }, [props.pipeline, props.running, monaco, editor]);
 
   // Hook to update the map of source line to instruction.
   useEffect(() => {
@@ -242,8 +243,8 @@ const Code = (props) => {
         .map((instruction) => map.set(instruction.Line, instruction));
     }
 
-    if (hoverDisposable) {
-      hoverDisposable.dispose();
+    if (hoverDisposableRef.current) {
+      hoverDisposableRef.current.dispose();
     }
 
     const disposable = monaco.languages.registerHoverProvider('mips', {
@@ -278,29 +279,14 @@ const Code = (props) => {
         };
       },
     });
-    setHoverCleanup(disposable);
-  }, [props.parsedInstructions, stageMap, monaco]); // eslint-disable-line @eslint-react/exhaustive-deps
-
-  const saveCodeToFile = () => {
-    const blob = new Blob([props.code], { type: 'text/plain' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'code.s';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  };
-
-  const loadCodeFromFile = (event) => {
-    const file = event.target.files[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      props.onChangeValue(e.target.result);
+    hoverDisposableRef.current = disposable;
+    return () => {
+      if (hoverDisposableRef.current === disposable) {
+        hoverDisposableRef.current.dispose();
+        hoverDisposableRef.current = null;
+      }
     };
-    reader.readAsText(file);
-  };
+  }, [props.parsedInstructions, stageMap, monaco]);
 
   const editorDidMount = (editor, monaco) => {
     // Expose monaco and editor to window for testing purposes
@@ -318,8 +304,7 @@ const Code = (props) => {
 
     // Enable Vi mode if viMode prop is true
     if (props.viMode) {
-      const vim = initVimMode(editor);
-      setVimInstance(vim);
+      vimInstanceRef.current = initVimMode(editor);
     }
 
     // Ensure the required command is registered
@@ -336,14 +321,19 @@ const Code = (props) => {
   // Hook to dynamically toggle Vi mode when viMode prop changes
   useEffect(() => {
     if (!editor) return;
-    if (props.viMode) {
-      const vim = initVimMode(editor);
-      setVimInstance(vim);
-    } else if (vimInstance) {
-      vimInstance.dispose();
-      setVimInstance(null);
+    if (props.viMode && !vimInstanceRef.current) {
+      vimInstanceRef.current = initVimMode(editor);
+    } else if (!props.viMode && vimInstanceRef.current) {
+      vimInstanceRef.current.dispose();
+      vimInstanceRef.current = null;
     }
-  }, [props.viMode]);
+    return () => {
+      if (vimInstanceRef.current) {
+        vimInstanceRef.current.dispose();
+        vimInstanceRef.current = null;
+      }
+    };
+  }, [editor, props.viMode]);
 
   const options = {
     selectOnLineNumbers: true,


### PR DESCRIPTION
## Summary
- Code.js pipeline decorations: moved Monaco decoration IDs into a ref and added the editor dependency so pipeline marker updates stay truthful without re-running from decoration state.
- Code.js Vim toggle: moved the Vim adapter into a ref and depended on editor + viMode so mid-session enable/disable is handled without stale closures.
- Code.js parse markers / CacheConfig sync: verified current master already has truthful deps (parsingErrors/editor/monaco and l1d/l1i/onChange); added regression coverage for both behaviors.

## Playwright coverage
- syntax errors update Monaco error markers
- Vim mode can be enabled and disabled after the editor mounts
- cache config changes synchronize before the next run

## Verification
- ./node_modules/.bin/eslint src/webapp/components/Code.js src/webapp/components/CacheConfig.js | no exhaustive-deps findings
- node --check src/test/webapp/exhaustive-deps-regressions.spec.js
- ./node_modules/.bin/prettier --check src/webapp/components/Code.js src/webapp/components/CacheConfig.js src/test/webapp/exhaustive-deps-regressions.spec.js
- npm run build
- ./gradlew war
- npm run build-dbg
- npx playwright test src/test/webapp/exhaustive-deps-regressions.spec.js --workers=1 (blocked locally: Playwright Chromium executable is not installed; CI can run the spec)

Closes #1717