### PR TITLE
Revert "remove misleading stall stats" (#1816)

### DIFF
--- a/docs/user/en/src/user-interface-web.rst
+++ b/docs/user/en/src/user-interface-web.rst
@@ -254,7 +254,7 @@ Counters about the program execution:
 * number of executed cycles;
 * number of executed instructions;
 * CPI — cycles per instruction (``cycles / instructions``);
-* RAW stalls;
+* RAW, WAW and structural stalls;
 * L1 instruction-cache reads and misses;
 * L1 data-cache reads, read misses, writes and write misses (only
   meaningful when the cache simulator is configured — see *Cache

--- a/docs/user/it/src/user-interface-web.rst
+++ b/docs/user/it/src/user-interface-web.rst
@@ -265,7 +265,7 @@ Contatori sull'esecuzione del programma:
 * numero di cicli eseguiti;
 * numero di istruzioni eseguite;
 * CPI — cicli per istruzione (``cicli / istruzioni``);
-* stalli RAW;
+* stalli RAW, WAW e strutturali;
 * letture e miss della L1 istruzioni;
 * letture, miss in lettura, scritture e miss in scrittura della L1
   dati (significativi solo se la cache è opportunamente configurata —

--- a/docs/user/zh/src/user-interface-web.rst
+++ b/docs/user/zh/src/user-interface-web.rst
@@ -203,7 +203,7 @@ Statistics
 * 已执行的周期数；
 * 已执行的指令数；
 * CPI —— 每条指令的平均周期数（``cycles / instructions``）；
-* RAW 停顿数；
+* RAW、WAW 和结构性停顿数；
 * L1 指令缓存的读次数和未命中次数；
 * L1 数据缓存的读次数、读未命中、写次数和写未命中（仅在配置缓存
   模拟器时才有意义 —— 见 *Cache Configuration*）。

--- a/src/main/java/org/edumips64/ui/swing/GUIStatistics.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIStatistics.java
@@ -43,7 +43,7 @@ public class GUIStatistics extends GUIComponent {
 
   StatPanel statPanel;
   JScrollPane jsp;
-  private int nCycles, nInstructions, rawStalls, codeSize;
+  private int nCycles, nInstructions, rawStalls, codeSize, WAWStalls, dividerStalls, memoryStalls;
 
   private int L1I_reads, L1I_reads_misses, L1D_reads, L1D_reads_misses, L1D_writes, L1D_writes_misses;
 
@@ -65,7 +65,8 @@ public class GUIStatistics extends GUIComponent {
   class StatPanel extends JPanel {
     private static final long serialVersionUID = 81105844698513914L;
     JList<? extends String> statList;
-    String [] statistics = {" Execution", " 0 Cycles", " 0 Instructions", " ", " Stalls", " 0 RAW Stalls",
+    String [] statistics = {" Execution", " 0 Cycles", " 0 Instructions", " ", " Stalls", " 0 RAW Stalls", " 0 WAW Stalls",
+                            " 0 Structural Stalls(Divider not available)", "0 Structural Stalls (Memory not available)",
                             " Code Size", " 0 Bytes", "FPU info", "FCSR", "FCSRGroups", "FCSRMnemonics", "FCSRValues",
                             " L1 Cache Stats", " 0 L1I Reads", " 0 L1I Read Misses",
                             " 0 L1D Reads", " 0 L1D Read Misses", " 0 L1D Writes", " 0 L1D Write Misses"
@@ -96,6 +97,9 @@ public class GUIStatistics extends GUIComponent {
 
     rawStalls = cpu.getRAWStalls();
     codeSize = (memory.getInstructionsNumber()) * 4;
+    WAWStalls = cpu.getWAWStalls();
+    dividerStalls = cpu.getStructuralStallsDivider();
+    memoryStalls = cpu.getStructuralStallsMemory();
     L1I_reads = (int) cachesim.getL1InstructionCache().getStats().getReadAccesses();
     L1I_reads_misses = (int) cachesim.getL1InstructionCache().getStats().getReadMisses();
     L1D_reads = (int) cachesim.getL1DataCache().getStats().getReadAccesses();
@@ -168,48 +172,57 @@ public class GUIStatistics extends GUIComponent {
         }
         return label;
       case 6:
+        label.setText(" " + WAWStalls + " " + CurrentLocale.getString("WAWS"));
+        return label;
+      case 7:
+        label.setText(" " + dividerStalls + " " + CurrentLocale.getString("STRUCTS_DIVNOTAVAILABLE"));
+        return label;
+      case 8:
+        label.setText(" " + memoryStalls  + " " + CurrentLocale.getString("STRUCTS_MEMNOTAVAILABLE"));
+        return label;
+      case 9:
         label.setText(" " + CurrentLocale.getString("CSIZE"));
         label.setForeground(Color.red);
         return label;
-      case 7:
+      case 10:
         label.setText(" " + codeSize + " " + CurrentLocale.getString("BYTES"));
         return label;
-      case 8:
+      case 11:
         label.setText(" " + CurrentLocale.getString("FPUINFO"));
         label.setForeground(Color.red);
         return label;
-      case 9:
+      case 12:
         label.setText(" " + CurrentLocale.getString("FPUFCSR"));
         return label;
-      case 10:
+      case 13:
         label.setText(" " + "    FCC       Cause EnablFlag RM");
         return label;
-      case 11:
+      case 14:
         label.setText(" " + "7654321 0      VZOUIVZOUIVZOUI");
         return label;
-      case 12:
+      case 15:
         label.setText(" " + cpu.getFCSR().getBinString());
         return label;
-      case 13:
+      case 16:
         label.setText(" " + CurrentLocale.getString("L1CACHESTATS"));
         label.setForeground(Color.red);
         return label;
-      case 14:
+      case 17:
         label.setText(" " + L1I_reads + " " + CurrentLocale.getString("L1I READS"));
         return label;
-      case 15:
+      case 18:
         label.setText(" " + L1I_reads_misses + " " + CurrentLocale.getString("L1I READ MISSES"));
         return label;
-      case 16:
+      case 19:
         label.setText(" " + L1D_reads + " " + CurrentLocale.getString("L1D READS"));
         return label;
-      case 17:
+      case 20:
         label.setText(" " + L1D_reads_misses + " " + CurrentLocale.getString("L1D READ MISSES"));
         return label;
-      case 18:
+      case 21:
         label.setText(" " + L1D_writes + " " + CurrentLocale.getString("L1D WRITES"));
         return label;
-      case 19:
+      case 22:
         label.setText(" " + L1D_writes_misses + " " + CurrentLocale.getString("L1D WRITE MISSES"));
         return label;
       }

--- a/src/test/webapp/clear-button.spec.js
+++ b/src/test/webapp/clear-button.spec.js
@@ -60,6 +60,10 @@ SYSCALL 0
 
   const rawStallsAfterClear = await page.locator('#stat-raw-stalls').textContent();
   expect(rawStallsAfterClear).toBe('0');
+  const wawStallsAfterClear = await page.locator('#stat-waw-stalls').textContent();
+  expect(wawStallsAfterClear).toBe('0');
+  const structuralStallsAfterClear = await page.locator('#stat-structural-stalls').textContent();
+  expect(structuralStallsAfterClear).toBe('0');
 
   // 2) Verify that the code is the trivial "syscall 0" program
   // Get the editor content by reading from Monaco's model

--- a/src/test/webapp/forwarding.spec.js
+++ b/src/test/webapp/forwarding.spec.js
@@ -117,7 +117,15 @@ async function getExecutionStats(page) {
     (await page.locator('#stat-raw-stalls').textContent()) || '0',
     10
   );
-  return { cycles, instructions, rawStalls };
+  const wawStalls = parseInt(
+    (await page.locator('#stat-waw-stalls').textContent()) || '0',
+    10
+  );
+  const structuralStalls = parseInt(
+    (await page.locator('#stat-structural-stalls').textContent()) || '0',
+    10
+  );
+  return { cycles, instructions, rawStalls, wawStalls, structuralStalls };
 }
 
 /**
@@ -271,6 +279,8 @@ test('forwarding is applied on a fresh session and yields identical cycle/stall 
   expect(session2Stats.cycles).toBe(session1Stats.cycles);
   expect(session2Stats.instructions).toBe(session1Stats.instructions);
   expect(session2Stats.rawStalls).toBe(session1Stats.rawStalls);
+  expect(session2Stats.wawStalls).toBe(session1Stats.wawStalls);
+  expect(session2Stats.structuralStalls).toBe(session1Stats.structuralStalls);
 
   // And specifically the forwarding-enabled value, not the default one.
   expect(session2Stats.cycles).toBe(EXPECTED_WITH_FORWARDING.cycles);

--- a/src/test/webapp/pipeline-stalls.spec.js
+++ b/src/test/webapp/pipeline-stalls.spec.js
@@ -232,6 +232,7 @@ SYSCALL 0
   expect(snap.ID.stall).toBe('WAW');
   expect(snap.ID.fill).toBe(STALL_COLOR);
 
+  expect(await readStat(page, 'stat-waw-stalls')).toBeGreaterThanOrEqual(1);
 });
 
 /**

--- a/src/webapp/components/Statistics.js
+++ b/src/webapp/components/Statistics.js
@@ -23,130 +23,69 @@ const Row = ({ label, value, valueId }) => {
 // pluralization, just me playing around with React.
 const PluralRow = ({ label, value, valueId }) => {
   const pluralSuffix = value !== 1 ? 's' : '';
-  return (
-    <Row label={`${label}${pluralSuffix}`} value={value} valueId={valueId} />
-  );
+  return <Row label={`${label}${pluralSuffix}`} value={value} valueId={valueId} />;
 };
 
 const Statistics = ({
   cycles,
   instructions,
   rawStalls,
-  L1I_reads,
-  L1I_misses,
-  L1D_reads,
-  L1D_reads_misses,
-  L1D_writes,
-  L1D_writes_misses,
+  wawStalls,
+  memoryStalls, L1I_reads, L1I_misses,L1D_reads,L1D_reads_misses,L1D_writes,L1D_writes_misses,
+  codeSizeBytes,
+  fcsr,
 }) => {
   // Common table style to ensure consistent layout
-  const tableStyle = {
+const tableStyle = {
     border: 'none',
     width: '100%',
     tableLayout: 'fixed', // Forces consistent column widths
-  };
+};
   // TODO: FCSR.
   return (
-    <React.Fragment>
-      <div id="statistics">
-        <div>
-          <table style={tableStyle}>
+    <div id="statistics">
+      <div>
+        <table style={tableStyle}>
             <tbody>
-              <tr>
-                <th
-                  colSpan="2"
-                  style={{
-                    textAlign: 'left',
-                    fontSize: '1rem',
-                    padding: '0.5rem 0',
-                  }}
-                >
-                  Execution
+            <tr>
+                <th colSpan="2" style={{textAlign: 'left', fontSize: '1rem', padding: '0.5rem 0'}}>
+                    Execution
                 </th>
-              </tr>
-              <PluralRow value={cycles} label="Cycle" valueId="stat-cycles" />
-              <PluralRow
-                value={instructions}
-                label="Instruction"
-                valueId="stat-instructions"
-              />
-              <Row
-                value={
-                  instructions === 0 ? 0 : (cycles / instructions).toFixed(2)
-                }
-                label="Cycles per Instructions (CPI)"
-              />
+            </tr>
+              <PluralRow value={cycles} label="Cycle" valueId="stat-cycles"/>
+              <PluralRow value={instructions} label="Instruction" valueId="stat-instructions"/>
+            <Row value={instructions === 0 ? 0 : (cycles / instructions).toFixed(2)}
+                 label="Cycles per Instructions (CPI)"/>
             </tbody>
-          </table>
-        </div>
+        </table>
+      </div>
 
         <div>
-          <table style={tableStyle}>
-            <tbody>
-              <tr>
-                <th
-                  colSpan="2"
-                  style={{
-                    textAlign: 'left',
-                    fontSize: '1rem',
-                    padding: '0.5rem 0',
-                  }}
-                >
-                  Stalls
-                </th>
-              </tr>
-              <PluralRow
-                value={rawStalls}
-                label="RAW Stall"
-                valueId="stat-raw-stalls"
-              />
-              <tr>
-                <th
-                  colSpan="2"
-                  style={{
-                    textAlign: 'left',
-                    fontSize: '1rem',
-                    padding: '0.5rem 0',
-                  }}
-                >
-                  Cache Memory Statistics
-                </th>
-              </tr>
-              <Row
-                value={L1I_reads}
-                label="L1 Instruction Reads"
-                valueId="stat-l1i-reads"
-              />
-              <Row
-                value={L1I_misses}
-                label="L1 Instruction Misses"
-                valueId="stat-l1i-misses"
-              />
-              <Row
-                value={L1D_reads}
-                label="L1 Data Reads"
-                valueId="stat-l1d-reads"
-              />
-              <Row
-                value={L1D_reads_misses}
-                label="L1 Data Read Misses"
-                valueId="stat-l1d-read-misses"
-              />
-              <Row
-                value={L1D_writes}
-                label="L1 Data Writes"
-                valueId="stat-l1d-writes"
-              />
-              <Row
-                value={L1D_writes_misses}
-                label="L1 Data Write Misses"
-                valueId="stat-l1d-write-misses"
-              />
-            </tbody>
-          </table>
+            <table style={tableStyle}>
+                <tbody>
+                <tr>
+                    <th colSpan="2" style={{textAlign: 'left', fontSize: '1rem', padding: '0.5rem 0'}}>
+                        Stalls
+                    </th>
+                </tr>
+                <PluralRow value={rawStalls} label="RAW Stall" valueId="stat-raw-stalls"/>
+                <PluralRow value={wawStalls} label="WAW Stall" valueId="stat-waw-stalls"/>
+                <PluralRow value={memoryStalls} label="Structural Stall" valueId="stat-structural-stalls"/>
+                <tr>
+                    <th colSpan="2" style={{textAlign: 'left', fontSize: '1rem', padding: '0.5rem 0'}}>
+                        Cache Memory Statistics
+                    </th>
+                </tr>
+                <Row value={L1I_reads} label="L1 Instruction Reads" valueId="stat-l1i-reads"/>
+                <Row value={L1I_misses} label="L1 Instruction Misses" valueId="stat-l1i-misses"/>
+                <Row value={L1D_reads} label="L1 Data Reads" valueId="stat-l1d-reads"/>
+                <Row value={L1D_reads_misses} label="L1 Data Read Misses" valueId="stat-l1d-read-misses"/>
+                <Row value={L1D_writes} label="L1 Data Writes" valueId="stat-l1d-writes"/>
+                <Row value={L1D_writes_misses} label="L1 Data Write Misses" valueId="stat-l1d-write-misses"/>
+                </tbody>
+            </table>
         </div>
-      </div>
-    </React.Fragment>
+    </div>
   );
 };
 


### PR DESCRIPTION
Reverts PR #1816 (commit 5b6637fe) at the maintainer's request — the decision on which stall statistics to remove from the stats panels is **still under discussion**.

This restores the WAW and structural stall statistics to the Swing and web statistics panels, along with the related Playwright assertions and EN/IT/ZH documentation. No pipeline-stall logic was ever changed by #1816, so this is a clean restore of the display + tests + docs.

Reopening #1799 to continue the discussion.

Refs #1799, #692.