### PR TITLE
fix: web UI Structural Stall counter ignores divider/funcUnit/EX stalls

### DIFF
--- a/src/main/java/org/edumips64/client/ResultFactory.java
+++ b/src/main/java/org/edumips64/client/ResultFactory.java
@@ -297,6 +297,8 @@ public class ResultFactory {
             .put("wawStalls", cpu.getWAWStalls())
             .put("dividerStalls", cpu.getStructuralStallsDivider())
             .put("memoryStalls", cpu.getStructuralStallsMemory())
+            .put("exStalls", cpu.getStructuralStallsEX())
+            .put("funcUnitStalls", cpu.getStructuralStallsFuncUnit())
                 .put("L1I_reads", cachesim.getL1InstructionCache().getStats().getReadAccesses())
                 .put("L1I_misses", cachesim.getL1InstructionCache().getStats().getReadMisses())
                 .put("L1D_reads", cachesim.getL1DataCache().getStats().getReadAccesses())

--- a/src/test/webapp/pipeline-stalls.spec.js
+++ b/src/test/webapp/pipeline-stalls.spec.js
@@ -273,9 +273,8 @@ SYSCALL 0
   expect(snap.ID.stall).toBe('Struct: Div');
   expect(snap.ID.fill).toBe(STALL_COLOR);
 
-  // Note: the Statistics panel's "Structural Stall" counter only counts
-  // memory-structural stalls (`getStructuralStallsMemory()`), not divider
-  // stalls, so we don't assert anything about it here. The SVG check above
-  // is the authoritative verification that the Web UI surfaced the StDiv
-  // tag for the second DIV.D.
+  // Note: the Statistics panel's "Structural Stall" counter now sums all four
+  // structural-stall counters (divider, memory, EX, funcUnit), so we assert
+  // that it reflects at least the divider stalls seen above.
+  expect(await readStat(page, 'stat-structural-stalls')).toBeGreaterThanOrEqual(1);
 });

--- a/src/webapp/components/Statistics.js
+++ b/src/webapp/components/Statistics.js
@@ -31,7 +31,7 @@ const Statistics = ({
   instructions,
   rawStalls,
   wawStalls,
-  memoryStalls, L1I_reads, L1I_misses,L1D_reads,L1D_reads_misses,L1D_writes,L1D_writes_misses,
+  memoryStalls, dividerStalls, exStalls, funcUnitStalls, L1I_reads, L1I_misses,L1D_reads,L1D_reads_misses,L1D_writes,L1D_writes_misses,
   codeSizeBytes,
   fcsr,
 }) => {
@@ -70,7 +70,7 @@ const tableStyle = {
                 </tr>
                 <PluralRow value={rawStalls} label="RAW Stall" valueId="stat-raw-stalls"/>
                 <PluralRow value={wawStalls} label="WAW Stall" valueId="stat-waw-stalls"/>
-                <PluralRow value={memoryStalls} label="Structural Stall" valueId="stat-structural-stalls"/>
+                <PluralRow value={(dividerStalls || 0) + (memoryStalls || 0) + (exStalls || 0) + (funcUnitStalls || 0)} label="Structural Stall" valueId="stat-structural-stalls"/>
                 <tr>
                     <th colSpan="2" style={{textAlign: 'left', fontSize: '1rem', padding: '0.5rem 0'}}>
                         Cache Memory Statistics


### PR DESCRIPTION
Closes #1818

## Root cause

`ResultFactory.java` exported only `dividerStalls` and `memoryStalls`, while `Statistics.js` displayed only `memoryStalls` for the "Structural Stall" row. Programs that use the FPU divider (e.g. `DIV.D`) showed 0 structural stalls in the web UI despite the core reporting non-zero divider stalls (`getStructuralStallsDivider()`).

## Fix

1. **`ResultFactory.java`**: export two additional fields — `exStalls` (`getStructuralStallsEX()`) and `funcUnitStalls` (`getStructuralStallsFuncUnit()`) — alongside the existing `dividerStalls` and `memoryStalls`.
2. **`Statistics.js`**: destructure all four structural-stall props and compute the total:
   `(dividerStalls || 0) + (memoryStalls || 0) + (exStalls || 0) + (funcUnitStalls || 0)`
   and render it in the existing `stat-structural-stalls` row.
3. **`pipeline-stalls.spec.js`**: replace the placeholder comment in the Structural Divider hazard test with a real assertion (`stat-structural-stalls >= 1`).

The Swing UI (`GUIStatistics.java`) already has separate rows for each stall type and is unaffected.