### PR TITLE
ci: add workflow_dispatch trigger for on-demand master builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - master
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 # Read-only by default. No job in this workflow needs more.
 permissions:
@@ -23,7 +24,7 @@ permissions:
 
 jobs:
   # Detect which files changed in the PR to conditionally run expensive builds.
-  # On schedule runs, all outputs are set to 'true' so every build runs.
+  # On schedule and manual (workflow_dispatch) runs, all outputs are set to 'true' so every build runs.
   detect-changes:
     name: Detect file changes
     runs-on: ubuntu-latest
@@ -31,8 +32,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      snap: ${{ github.event_name == 'schedule' && 'true' || steps.changes.outputs.snap }}
-      electron: ${{ github.event_name == 'schedule' && 'true' || steps.changes.outputs.electron }}
+      snap: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'true' || steps.changes.outputs.snap }}
+      electron: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'true' || steps.changes.outputs.electron }}
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Adds a `workflow_dispatch:` trigger to `.github/workflows/ci.yml` so a maintainer can run the full validating CI on `master` on demand — from the Actions **Run workflow** button or `gh workflow run ci.yml --ref master`.

## Why

`promote-web.yml` (and the rollback/nightly tooling) promote the `web` artifact from a **successful `ci.yml` run on `master`**. Until now, the only such artifact came from the daily scheduled run (cron `0 0 * * *`). That meant promoting the *current* master to production required waiting for the next nightly CI build. This trigger provides an on-demand "build current master" button that feeds the existing promotion flow — no change to `promote-web.yml` is needed, because a `workflow_dispatch` run on `master` already satisfies its validation (path = `ci.yml`, branch = `master`, conclusion = `success`, `web` artifact present).

## Changes (single file: `.github/workflows/ci.yml`)

- Add `workflow_dispatch:` to the `on:` block (no inputs).
- Extend the `detect-changes` force-build condition so manual runs build **everything** (snap + electron), matching scheduled-run behavior — a manual run validates the complete build matrix:
  `(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'true' || …`
- Update the accompanying comment.

## Safety / no behavior change for existing events

All pull-request-only logic already degrades correctly on non-PR events and is **untouched**:
- The `paths-filter` checkout step and the `save-pr-metadata` job are gated by `if: github.event_name == 'pull_request'` → skipped on dispatch.
- Every reusable-workflow `ref:` uses `github.event.pull_request.head.sha || github.sha` → resolves to master HEAD on dispatch.
- `build-and-test-snap`'s `…user.login != 'dependabot[bot]'` guards evaluate true on dispatch (null login).
- `pr-reports.yml` (triggered via `workflow_run`) gates its Azure deploy + preview comment on `workflow_run.event == 'pull_request'`, so those are correctly skipped for manual runs.

## Validation

- `actionlint` clean.