### PR TITLE
ci: unify build+promote — make run_id optional on promote-web.yml

### DIFF
--- a/.github/workflows/promote-web.yml
+++ b/.github/workflows/promote-web.yml
@@ -1,25 +1,68 @@
+# Promote Web to Production
+#
+# Two operating modes, selected by whether `run_id` is supplied:
+#
+# FRESH MODE (run_id empty — "one-click ship master"):
+#   1. `build` job: builds + tests current master HEAD via the shared
+#      build-web.yml reusable workflow.  No access to PAT_WEBUI.
+#   2. `promote` job: downloads the `web` artifact produced by step 1
+#      (using this workflow's own run ID) and deploys it to Pages.
+#
+# EXTERNAL MODE (run_id provided — rollback / re-promote / promote-arbitrary):
+#   1. `build` job: SKIPPED.
+#   2. `promote` job: validates the given ci.yml run (same-repo, master,
+#      success, has 'web' artifact) and promotes that artifact to Pages.
+#
+# Security model (unchanged):
+#   - Both jobs are gated on `github.actor == 'lupino3'` AND
+#     `github.ref_name == 'master'`.  The master-only gate ensures the
+#     workflow file itself is the audited version; a tampered copy on a
+#     feature branch can never reach the PAT_WEBUI secrets.
+#   - The `build` job has only `contents: read` and never sees PAT_WEBUI.
+#   - The `concurrency` lock (web-pages-deploy) is on the `promote` job
+#     only, so a fresh-mode `build` is not serialised by the Pages lock.
+
 name: Promote Web to Production
 
 on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'CI run ID whose "web" artifact to promote'
-        required: true
+        description: 'CI run ID whose "web" artifact to promote. Leave empty to build and promote the current master HEAD.'
+        required: false
         type: string
 
-# Serialise all Pages writes; never cancel an in-flight promotion.
-concurrency:
-  group: web-pages-deploy
-  cancel-in-progress: false
-
 jobs:
+  # Build a fresh web artifact from current master when no run_id is supplied.
+  # Runs only for the maintainer, only from master, and only in "build fresh"
+  # mode. Uses the same reusable build as CI; it has no access to PAT_WEBUI.
+  build:
+    name: Build web artifact from master
+    if: github.actor == 'lupino3' && github.ref_name == 'master' && inputs.run_id == ''
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-web.yml
+    with:
+      ref: ${{ github.sha }}
+
   promote:
     name: Promote web artifact to production
-    # Only the maintainer (lupino3) may trigger this; workflow_dispatch is
-    # already collaborator-gated, but belt-and-suspenders actor check here.
-    if: github.actor == 'lupino3'
+    needs: [build]
+    # always() is required so this job runs even when `build` was skipped
+    # (external mode).  The mode-specific result check provides the real gate.
+    if: >-
+      always() &&
+      github.actor == 'lupino3' &&
+      github.ref_name == 'master' &&
+      (
+        (inputs.run_id == '' && needs.build.result == 'success') ||
+        (inputs.run_id != '' && needs.build.result == 'skipped')
+      )
     runs-on: ubuntu-latest
+    # Serialise all Pages writes; never cancel an in-flight promotion.
+    concurrency:
+      group: web-pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: read
       # Required to call gh api / gh run download against the Actions API.
@@ -27,10 +70,11 @@ jobs:
 
     steps:
       # ------------------------------------------------------------------
-      # 1. Validate the source CI run before touching anything.
+      # 1. Determine source: validate an external CI run OR use this run.
       # ------------------------------------------------------------------
-      - name: Validate CI run
+      - name: Validate CI run (external mode)
         id: validate
+        if: inputs.run_id != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ inputs.run_id }}
@@ -71,20 +115,40 @@ jobs:
 
           echo "Validation passed."
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "source_run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Set source from current run (fresh mode)
+        id: fresh_source
+        if: inputs.run_id == ''
+        run: |
+          set -euo pipefail
+          echo "head_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "source_run_id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      # Consolidate outputs from whichever of the two steps above ran.
+      # Exactly one will have populated its outputs; the other will be empty.
+      - name: Consolidate source outputs
+        id: source
+        run: |
+          set -euo pipefail
+          HEAD_SHA="${{ steps.validate.outputs.head_sha }}${{ steps.fresh_source.outputs.head_sha }}"
+          SOURCE_RUN_ID="${{ steps.validate.outputs.source_run_id }}${{ steps.fresh_source.outputs.source_run_id }}"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "source_run_id=${SOURCE_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       # ------------------------------------------------------------------
-      # 2. Checkout THIS repo at the validated SHA (for git describe).
+      # 2. Checkout THIS repo at the promoted SHA (for git describe).
       # ------------------------------------------------------------------
       - name: Checkout edumips64 at promoted SHA
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.validate.outputs.head_sha }}
+          ref: ${{ steps.source.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Compute build identity
         id: build_id
         env:
-          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
         run: |
           set -euo pipefail
           # git describe relative to the promoted commit; strip leading 'v'.
@@ -97,18 +161,32 @@ jobs:
           echo "targetRelease=${TARGET_RELEASE}" >> "$GITHUB_OUTPUT"
 
       # ------------------------------------------------------------------
-      # 3. Download the web artifact from the validated CI run.
+      # 3. Download the web artifact from the source run (with retry to
+      #    tolerate same-run artifact API propagation latency in fresh mode).
       # ------------------------------------------------------------------
       - name: Download web artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ inputs.run_id }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
         run: |
           set -euo pipefail
           mkdir -p artifact/web
-          gh run download "${RUN_ID}" --name web --dir artifact/web
+          downloaded=
+          for attempt in 1 2 3; do
+            if gh run download "${SOURCE_RUN_ID}" --name web --dir artifact/web; then
+              downloaded=yes
+              break
+            fi
+            echo "Attempt ${attempt} failed; retrying in 5s..."
+            sleep 5
+          done
+          [[ -n "$downloaded" ]] \
+            || { echo "ERROR: Failed to download 'web' artifact from run ${SOURCE_RUN_ID} after 3 attempts"; exit 1; }
           echo "Artifact contents:"
           ls artifact/web/
+          # Guard against an empty/partial artifact reaching the deploy script.
+          [[ -n "$(ls -A artifact/web/)" ]] \
+            || { echo "ERROR: Downloaded 'web' artifact is empty"; exit 1; }
 
       # ------------------------------------------------------------------
       # 4. Clone Pages repo, run script, commit, push.
@@ -127,7 +205,7 @@ jobs:
         env:
           BUILD: ${{ steps.build_id.outputs.build }}
           TARGET_RELEASE: ${{ steps.build_id.outputs.targetRelease }}
-          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
         run: |
           set -euo pipefail
           # Copy the script into the Pages-repo checkout.
@@ -143,7 +221,7 @@ jobs:
 
       - name: Commit and push to Pages repo
         env:
-          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
           BUILD: ${{ steps.build_id.outputs.build }}
         run: |
           set -euo pipefail

--- a/docs/design/web-promotion-and-versioning.md
+++ b/docs/design/web-promotion-and-versioning.md
@@ -44,15 +44,23 @@ This section describes the system as built. All workflows live in `.github/workf
 
 **Workflow:** `.github/workflows/promote-web.yml` (`workflow_dispatch`)
 
-**Inputs:** `run_id` (required) — the CI run whose `web` artifact to promote. Optional `sha` (derived from run if omitted).
+**Inputs:** `run_id` (optional) — the CI run whose `web` artifact to promote. Behavior depends on whether it is provided:
+- **Empty `run_id`** → **Build+promote current master:** a `build` job (using reusable `build-web.yml`) builds and tests the current master, then the `promote` job deploys that fresh artifact. One-click "ship current master" mode. Security preserved: `build-web.yml` has `contents: read` only and never sees `PAT_WEBUI`; the credential lives only in the `promote` job.
+- **`run_id` provided** → **Promote a specific validated run:** skip the build; validate that the given run is from this repo, ran `ci.yml`, concluded `success`, on `master` branch, and has a `web` artifact. Deploy that immutable artifact. This preserves rollback (re-promote a previously-validated run by id), re-promote (run the same id again), and audit (promote an arbitrary run by explicit id).
+
+**Dispatch requirement:** Must be dispatched from the `master` branch in both modes.
 
 **Access control:** `if: github.actor == 'lupino3'` — only Andrea can trigger.
 
-**Steps:**
-1. **Validate** the source CI run: confirms it belongs to this repo, ran `ci.yml`, concluded `success`, on `master` branch, and has a `web` artifact.
+**Steps (build+promote mode, no `run_id`):**
+1. **Build** (via reusable `build-web.yml` on current `master`): GWT worker + React/webpack bundle to `out/web/`, no secrets required.
+2. **Promote** (same flow as below, using current run id as `SOURCE_RUN_ID`).
+
+**Steps (promote-specific-run mode, `run_id` provided):**
+1. **Validate** the source CI run: confirms it belongs to this repo, ran `ci.yml`, concluded `success`, on `master` branch, and has a `web` artifact. Use the validated SHA and `run_id` as `SOURCE_RUN_ID`.
 2. **Checkout** this repo at the validated SHA with `fetch-depth: 0`.
 3. **Compute build identity:** `git describe --tags --match 'v*' --always <SHA> | sed 's/^v//'` → e.g. `1.4.0-2-gabc1234`. Also reads `targetRelease` from `gradle.properties`.
-4. **Download** the immutable `web` artifact from the validated run.
+4. **Download** the immutable `web` artifact from the source run (current run if build mode, or validated external run if promote-specific mode).
 5. **Clone** the Pages repo (`EduMIPS64/web.edumips.org`).
 6. **Run** `deploy-web-pages.py promote <artifact_dir> <build> <sha> <targetRelease> <actor>`:
    - Archives current root files → `/prev/` (on first run, seeds `/prev/` from existing root).
@@ -62,7 +70,7 @@ This section describes the system as built. All workflows live in `.github/workf
    - Ensures `CNAME` and `.nojekyll` are preserved.
 7. **Commit and push** to Pages repo.
 
-**Concurrency:** All Pages writes (promote, rollback, nightly) share a single `concurrency: group: web-pages-deploy` with `cancel-in-progress: false` to serialise safely.
+**Concurrency:** The `promote` job uses `concurrency: group: web-pages-deploy` with `cancel-in-progress: false` to serialise Pages writes safely across promote, rollback, and nightly operations. The `build` job (in fresh mode) is not serialised — parallel builds of different master snapshots do not conflict.
 
 ### Rollback
 
@@ -177,6 +185,8 @@ Organized by decision point. Each lists the option(s) we evaluated and rejected,
 |-----------------|-----------|
 | **(A) Environment approval gate** — add a `Production` GitHub Environment with required reviewers to the existing `deploy-prod` job; every master push creates a pending deployment awaiting approval. | Creates notification noise on every merge. No way to skip/batch. Artifact is rebuilt per push (not immutable promotion of an already-tested build). |
 | **(C) Git tag triggers deploy** — pushing a tag like `web-v<N>` triggers prod deploy by rebuilding from tag. | Rebuilding from tag means what you tested ≠ what you deploy (non-immutable). Agents could accidentally push tags. Extra manual step. |
+| **(D) Hard build+promote, dropping run_id** — a single workflow that ALWAYS rebuilds master and promotes, with no `run_id` input. | Removes the ability to re-promote / roll back by promoting a previously-validated run by id. Wastes CI resources by always rebuilding when an identical green artifact already exists. Loses audit trail of which runs have been shipped. |
+| **(E) Separate build→promote orchestrator** — keep two workflows but add a third that chains "trigger build, wait for green, then promote". | Cross-workflow orchestration is awkward in Actions (dispatch-then-wait has no native support). No capability gain over making `run_id` optional within a single workflow. Adds UI complexity (three workflows instead of one). |
 | **Auto-promote on green CI + time delay** — automatically promote the latest green build after N hours if no issues are raised. | Defeats the purpose of human gating. Andrea specifically wants an explicit manual action for production. |
 
 ### Rollback Hosting
@@ -248,6 +258,6 @@ Organized by decision point. Each lists the option(s) we evaluated and rejected,
 | 5 | Versions to retain in `/v/`? | 50. |
 | 6 | Build identity surfaces? | git-describe everywhere (desktop, CLI, web, docs). |
 | 7 | `package.json` version? | Leave stale at `1.0.0`; add comment noting it is unused. |
-| 8 | Workflow naming? | `promote-web.yml`, `rollback-web.yml`, `nightly-web.yml`. |
+| 8 | Workflow naming? | `promote-web.yml` (unifies build+promote with optional `run_id`), `rollback-web.yml`, `nightly-web.yml`. `promote-web.yml` serves both "build+promote current master" (empty `run_id`) and "promote a specific validated run" (with `run_id`). |
 | 9 | Nightly trigger? | Daily 01:00 UTC cron + `workflow_dispatch`. (Changed from initial "on-every-green-master-push" recommendation.) |
 | 10 | PR grouping? | Single PR (PR #1826) for all `edumips64` repo changes. Pages-repo layout bootstraps on first promotion run. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -450,12 +450,14 @@ in `release.yml` is disabled (`if: false`). Promotion is manual and gated.
 
 #### Promoting a build to production
 
+**`promote-web.yml` serves two modes:**
+
+**Mode 1: Build and promote current master (one-click ship)**
 1. Open **Actions → Promote Web to Production** (`promote-web.yml`).
-2. Click **Run workflow** and enter the **CI run ID** whose `web` artifact to ship.
-   (Find the run ID in the URL of any successful CI run on `master`.)
-3. The workflow validates the run (must be a successful `ci.yml` run on `master`
-   with a `web` artifact), then deploys it to the Pages repo
-   (`EduMIPS64/web.edumips.org`) with the following layout:
+2. Click **Run workflow**. Leave the **CI run ID** field **empty**.
+3. The workflow builds and tests the current `master` (via reusable `build-web.yml`, 
+   no secrets), then deploys the artifact to production.
+4. The Pages repo (`EduMIPS64/web.edumips.org`) receives the update with the following layout:
 
    ```
    web.edumips.org/
@@ -466,10 +468,21 @@ in `release.yml` is disabled (`if: false`). Promotion is manual and gated.
    └── manifest.json              ← {current, prev, sha, build, promotedAt, …}
    ```
 
-Only `lupino3` (Andrea) can trigger `promote-web.yml` (actor check enforced in
-the workflow, in addition to the collaborator gate on `workflow_dispatch`).
+**Mode 2: Promote a specific past CI run (rollback / re-promote)**
+1. Open **Actions → Promote Web to Production** (`promote-web.yml`).
+2. Click **Run workflow** and enter the **CI run ID** whose `web` artifact to ship.
+   (Find the run ID in the URL of any successful CI run on `master`.)
+3. The workflow validates the run (must be a successful `ci.yml` run on `master`
+   with a `web` artifact), then deploys it to production using the same layout as Mode 1.
+   This mode is useful for: rolling back to a previous good build (find its run ID and
+   re-promote), re-promoting the current production version by id, or auditing which
+   runs have shipped.
 
-The Pages-layout logic lives in `.github/scripts/deploy-web-pages.py`.
+**Details:**
+- Only `lupino3` (Andrea) can trigger `promote-web.yml` (actor check enforced in
+  the workflow, in addition to the collaborator gate on `workflow_dispatch`).
+- Must be dispatched from the `master` branch in both modes.
+- The Pages-layout logic lives in `.github/scripts/deploy-web-pages.py`.
 
 #### Rolling back
 
@@ -477,6 +490,8 @@ If the current production version is broken, open **Actions → Rollback Web
 Production** (`rollback-web.yml`) and click **Run workflow** (no inputs needed).
 This promotes `prev/` back to root and updates `manifest.json`. Gated to
 `lupino3` only.
+
+Alternatively, use Mode 2 of `promote-web.yml` to re-promote a previous good build by its run ID.
 
 #### Nightly channel
 


### PR DESCRIPTION
## What

Collapses *"manually build the current master"* and *"promote to production"* into a **single workflow** by making `promote-web.yml`'s `run_id` input **optional**.

| Dispatch | Behaviour |
|----------|-----------|
| **`run_id` empty** | A `build` job builds + tests current `master` (reusable `build-web.yml`), then the `promote` job ships that fresh artifact. **One-click "deploy current master".** |
| **`run_id` set** | Skip the build; validate that external `ci.yml` / `master` / `success` run and promote its `web` artifact. Preserves **rollback** (re-promote a previous good run by id), **re-promote**, and promoting an arbitrary validated run. |

This supersedes the standalone `ci.yml` `workflow_dispatch` trigger from #1829 (which I'll close) — `promote-web.yml` now does its own build, so there's no copy-paste of a run ID for the common case.

## Why

`promote-web.yml` promotes the immutable `web` artifact of a successful `master` CI run. Previously the *only* such artifact came from the daily scheduled CI, so shipping current master meant either waiting for nightly or a two-step dispatch + copy-run-id + dispatch dance. Making `run_id` optional gives one-click ergonomics **without** losing the immutable-artifact / promote-by-id capabilities the rollback design depends on.

## Design (rubber-duck reviewed)

- **`build` job:** `uses: ./.github/workflows/build-web.yml` with `ref: github.sha`; `if: actor == 'lupino3' && ref_name == 'master' && run_id == ''`. `contents: read` only — **never sees `PAT_WEBUI`**.
- **`promote` job:** `needs: [build]`, mode-specific result gate — `(run_id == '' && build.result == 'success') || (run_id != '' && build.result == 'skipped')`. Holds `PAT_WEBUI`.
- **Master-only gate on both jobs** so a tampered workflow file on a feature branch can never reach the deploy credentials.
- **Concurrency** (`web-pages-deploy`, no-cancel) moved to the `promote` job → fresh builds aren't serialised.
- **Single `SOURCE_RUN_ID`** (current run in fresh mode, else `run_id`) unifies the artifact download; retries 3× and **fails closed** on an empty/missing artifact.

## Docs

- **Design doc** — "Manual Gated Promotion" rewritten for the two modes; "Alternatives → Promotion Trigger" gains the two rejected variants (hard build-always-promote dropping `run_id`; separate build→promote orchestrator).
- **Developer guide** — promotion procedure documented as Mode 1 (empty `run_id`) / Mode 2 (specific run for rollback/re-promote).

## Validation

- `actionlint` clean.
- Control flow verified for both modes; no leftover required-`run_id` assumptions; credentialed steps unreachable without maintainer + master.

> Note: like the rest of this system, the credentialed promote path can only be exercised post-merge from `master`. I'll run the first real promotion (empty `run_id`) and verify the resulting Pages layout once this lands.