### PR TITLE
fix(ci): run monitoring tests against the deployed production commit

### DIFF
--- a/.github/workflows/monitor-webui.yml
+++ b/.github/workflows/monitor-webui.yml
@@ -8,7 +8,21 @@ jobs:
   monitor-ui:
     runs-on: ubuntu-latest
     steps:
+      - name: Get deployed commit SHA from production manifest
+        id: deployed
+        run: |
+          SHA=$(curl -sf https://web.edumips.org/manifest.json | jq -r '.sha')
+          if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+            echo "Failed to fetch deployed SHA from manifest.json" >&2
+            exit 1
+          fi
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Monitoring production at commit ${SHA}"
+
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.deployed.outputs.sha }}
+
       - name: Set up Node.JS
         uses: actions/setup-node@v6
         with:
@@ -24,4 +38,3 @@ jobs:
           timeout_minutes: 2
           retry_on: error
           command: npm run test
-


### PR DESCRIPTION
## Problem

The `monitor-webui` workflow always checks out **master** and runs those Playwright tests against `https://web.edumips.org`. Production is updated via a manual gated promotion (`promote-web.yml`), so it routinely lags behind master.

After #1835 (contextual run controls), master's `contextual-controls.spec.js` was rewritten for the new `RunControlsToolbar` architecture. But production is still running the old promoted build (`1.4.0-102-gc0027167`), where `#load-button` is hidden via `display: none` when `status === 'RUNNING'`. The new tests assert it's always visible → 3 tests fail on every monitor run.

## Fix

Before checking out the repo, fetch `https://web.edumips.org/manifest.json` (written by `deploy-web-pages.py` on every promotion) and extract the `sha` field — the full git commit SHA of the currently deployed build. Pass that SHA as `ref` to `actions/checkout`.

This ensures the Playwright test files always match the UI code they exercise. The fix is self-maintaining: as production is promoted to newer commits, the monitor automatically picks up the matching tests with no manual intervention.

If `manifest.json` is unreachable the step fails fast with a clear error message rather than a misleading test failure.

## What changed

- `.github/workflows/monitor-webui.yml`: add a `Get deployed commit SHA` step before `checkout`; pass `ref:` to `actions/checkout@v6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)