### PR TITLE
Fix: raw-element styles (stdout/scrollbars/borders) now follow the app theme, not the OS

### DIFF
--- a/src/test/webapp/sample-program-stdout.spec.js
+++ b/src/test/webapp/sample-program-stdout.spec.js
@@ -7,36 +7,80 @@ const {
 } = require('./test-utils');
 
 /**
- * Regression test for the "default sample produces no Standard Output" bug:
- * loading the default sample program preloaded in the editor, clicking Load
- * and then Run All, must result in the printf'd string being visible in the
- * Standard Output panel after the simulation completes.
+ * Regression test for the "Standard Output text invisible (white-on-light)"
+ * bug: when the OS is in dark mode but the user forces the app to the light
+ * theme, the global CSS media-query rule (`@media prefers-color-scheme: dark
+ * { textarea { color: white } }`) used to make the stdout text white on a
+ * light-theme background — invisible to the user.
  *
- * The default sample uses SYSCALL 5 (printf) to write a string containing
- * the substring "being tested!" and then SYSCALL 0 to halt.
+ * The fix makes StdOut.js theme-aware via MUI's useTheme() so its inline
+ * color/backgroundColor always follow the active MUI palette (overriding the
+ * stylesheet media-query rule) regardless of the OS colour scheme.
+ *
+ * This test reproduces the exact failure scenario:
+ *   OS = dark, app theme forced to 'light' via localStorage.
+ * It asserts both that the textarea VALUE contains "being tested!" AND that
+ * the rendered text colour contrasts with the background (i.e. is not
+ * white-on-light / invisible).
  */
-test('default sample program writes to standard output', async ({ page }) => {
+test('default sample stdout text is visible in light theme with dark OS', async ({ page }) => {
+  // Emulate OS dark preference while the app is forced to light theme.
+  await page.emulateMedia({ colorScheme: 'dark' });
+
+  // Seed localStorage BEFORE the app loads so useSetting picks it up.
+  // The key follows the edumips64:v1:<name> namespace; the value is
+  // JSON-serialised (JSON.stringify('light') === '"light"').
+  await page.addInitScript(() => {
+    window.localStorage.setItem('edumips64:v1:themeMode', '"light"');
+  });
+
   await page.goto(targetUri);
   await waitForPageReady(page);
 
-  // The default sample is preloaded — no edits needed.
   await removeOverlay(page);
 
-  // Load the program into the simulator.
+  // Load the default sample (preloaded in the editor).
   await page.waitForSelector('#load-button:not([disabled])', { timeout: 10000 });
   await page.click('#load-button');
   await page.mouse.move(0, 0);
 
-  // After load, the simulator enters READY: #run-button becomes enabled.
+  // Wait for READY state, then Run All.
   await page.waitForSelector('#run-button:not([disabled])', { timeout: 10000 });
-
-  // Run the whole program to completion.
   await page.click('#run-button');
+  await page.mouse.move(0, 0);
   await waitForSimulationComplete(page);
 
-  // Open the Standard Output accordion so the textarea becomes interactive.
+  // Open the Standard Output accordion.
   await page.locator('text=Standard Output').click();
 
-  // The default sample's printf output contains "being tested!".
+  // Sanity: the value must contain the expected string.
   await expect(page.locator('#stdout-view')).toContainText('being tested!');
+
+  // Visibility: read computed styles and assert the text is NOT effectively
+  // white (i.e. invisible on the light-theme background).
+  // When the bug is present (OS dark, app forced light, no theme-aware fix),
+  // the CSS media-query fires `textarea { color: white }`, making text
+  // invisible.  The fix applies inline MUI palette colours that win over the
+  // stylesheet, giving dark text (~luminance 0) in the light theme.
+  const styles = await page.locator('#stdout-view').evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { color: s.color, background: s.backgroundColor };
+  });
+
+  // Parse rgb(r, g, b[, a]) → perceived luminance (0 = black, 255 = white).
+  function parseBrightness(cssColor) {
+    const m = cssColor.match(/\d+/g);
+    if (!m || m.length < 3) return null;
+    const [r, g, b] = m.map(Number);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  const textBrightness = parseBrightness(styles.color);
+
+  // The text must NOT be near-white (luminance ≈ 255 means invisible on a
+  // light background).  Dark text in the MUI light theme palette is
+  // rgba(0,0,0,0.87) → luminance < 50.  We require strictly < 150 to catch
+  // any near-white colour while leaving room for mid-grey values.
+  expect(textBrightness).toBeLessThan(150);
 });
+

--- a/src/test/webapp/sample-program-stdout.spec.js
+++ b/src/test/webapp/sample-program-stdout.spec.js
@@ -97,3 +97,63 @@ test('stdout text is visible in light theme with dark OS', async ({ page }) => {
   expect(textBrightness).toBeLessThan(150);
 });
 
+/**
+ * Regression test for the BROADER root cause: raw-element CSS was gated on
+ * the OS `prefers-color-scheme` media query, desyncing from the user-selected
+ * app theme.  The fix publishes the resolved MUI palette mode to
+ * `html[data-theme]` (via useLayoutEffect in Simulator.js) and gates all
+ * raw-element rules on that attribute instead.
+ *
+ * This test validates the OPPOSITE direction:
+ *   OS = light, app theme forced to 'dark' via localStorage.
+ * Before the fix, the OS-light media query would NOT apply the dark textarea
+ * rule, so the textarea text would default to the base dark colour
+ * (rgba(0,0,0,0.87)) — nearly invisible on the dark-theme background.
+ * After the fix, `html[data-theme='dark']` fires regardless of OS and the
+ * textarea text is white (luminance ≈ 255).
+ */
+test('stdout text is visible in dark theme with light OS', async ({ page }) => {
+  // Emulate OS light preference while the app is forced to dark theme.
+  await page.emulateMedia({ colorScheme: 'light' });
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('edumips64:v1:themeMode', '"dark"');
+  });
+
+  await page.goto(targetUri);
+  await waitForPageReady(page);
+  await removeOverlay(page);
+
+  await loadProgram(page, STDOUT_PROGRAM);
+  await runToCompletion(page);
+
+  await page.locator('text=Standard Output').click();
+
+  await expect(page.locator('#stdout-view')).toContainText('being tested!');
+
+  // Assert the app published the resolved palette to the DOM.
+  const dataTheme = await page.evaluate(() =>
+    document.documentElement.getAttribute('data-theme')
+  );
+  expect(dataTheme).toBe('dark');
+
+  const styles = await page.locator('#stdout-view').evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { color: s.color, background: s.backgroundColor };
+  });
+
+  function parseBrightness(cssColor) {
+    const m = cssColor.match(/\d+/g);
+    if (!m || m.length < 3) return null;
+    const [r, g, b] = m.map(Number);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  const textBrightness = parseBrightness(styles.color);
+
+  // The text must be near-white (luminance > 150) — visible on the dark background.
+  // MUI dark palette text is white (rgb(255,255,255)) → luminance = 255.
+  // The StdOut.js theme-aware inline style guarantees this.
+  expect(textBrightness).toBeGreaterThan(150);
+});
+

--- a/src/test/webapp/sample-program-stdout.spec.js
+++ b/src/test/webapp/sample-program-stdout.spec.js
@@ -3,7 +3,8 @@ const {
   targetUri,
   removeOverlay,
   waitForPageReady,
-  waitForSimulationComplete,
+  loadProgram,
+  runToCompletion,
 } = require('./test-utils');
 
 /**
@@ -22,8 +23,28 @@ const {
  * It asserts both that the textarea VALUE contains "being tested!" AND that
  * the rendered text colour contrasts with the background (i.e. is not
  * white-on-light / invisible).
+ *
+ * A short SYSCALL 5 program (a handful of cycles) is used instead of the
+ * default 5020-cycle sample to keep CI fast under the Playwright coverage
+ * instrumentation, which slows JS execution enough that a long program
+ * exceeds the 30 s waitForSimulationComplete timeout.
  */
-test('default sample stdout text is visible in light theme with dark OS', async ({ page }) => {
+
+// Short MIPS64 program that prints "being tested!" via SYSCALL 5 (printf).
+// Mirrors the default sample's mechanism: store the format-string address at
+// fs_addr, point r14 at fs_addr, then syscall 5.  Runs in ~10 cycles.
+const STDOUT_PROGRAM = `.data
+format_str: .asciiz "being tested!"
+fs_addr:    .space 4
+.code
+  daddi r5, r0, format_str
+  sw    r5, fs_addr(r0)
+  daddi r14, r0, fs_addr
+  syscall 5
+  syscall 0
+`;
+
+test('stdout text is visible in light theme with dark OS', async ({ page }) => {
   // Emulate OS dark preference while the app is forced to light theme.
   await page.emulateMedia({ colorScheme: 'dark' });
 
@@ -36,19 +57,11 @@ test('default sample stdout text is visible in light theme with dark OS', async 
 
   await page.goto(targetUri);
   await waitForPageReady(page);
-
   await removeOverlay(page);
 
-  // Load the default sample (preloaded in the editor).
-  await page.waitForSelector('#load-button:not([disabled])', { timeout: 10000 });
-  await page.click('#load-button');
-  await page.mouse.move(0, 0);
-
-  // Wait for READY state, then Run All.
-  await page.waitForSelector('#run-button:not([disabled])', { timeout: 10000 });
-  await page.click('#run-button');
-  await page.mouse.move(0, 0);
-  await waitForSimulationComplete(page);
+  // Load the short program and run it to completion using the CI-proven helpers.
+  await loadProgram(page, STDOUT_PROGRAM);
+  await runToCompletion(page);
 
   // Open the Standard Output accordion.
   await page.locator('text=Standard Output').click();

--- a/src/test/webapp/sample-program-stdout.spec.js
+++ b/src/test/webapp/sample-program-stdout.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('./fixtures');
+const {
+  targetUri,
+  removeOverlay,
+  waitForPageReady,
+  waitForSimulationComplete,
+} = require('./test-utils');
+
+/**
+ * Regression test for the "default sample produces no Standard Output" bug:
+ * loading the default sample program preloaded in the editor, clicking Load
+ * and then Run All, must result in the printf'd string being visible in the
+ * Standard Output panel after the simulation completes.
+ *
+ * The default sample uses SYSCALL 5 (printf) to write a string containing
+ * the substring "being tested!" and then SYSCALL 0 to halt.
+ */
+test('default sample program writes to standard output', async ({ page }) => {
+  await page.goto(targetUri);
+  await waitForPageReady(page);
+
+  // The default sample is preloaded — no edits needed.
+  await removeOverlay(page);
+
+  // Load the program into the simulator.
+  await page.waitForSelector('#load-button:not([disabled])', { timeout: 10000 });
+  await page.click('#load-button');
+  await page.mouse.move(0, 0);
+
+  // After load, the simulator enters READY: #run-button becomes enabled.
+  await page.waitForSelector('#run-button:not([disabled])', { timeout: 10000 });
+
+  // Run the whole program to completion.
+  await page.click('#run-button');
+  await waitForSimulationComplete(page);
+
+  // Open the Standard Output accordion so the textarea becomes interactive.
+  await page.locator('text=Standard Output').click();
+
+  // The default sample's printf output contains "being tested!".
+  await expect(page.locator('#stdout-view')).toContainText('being tested!');
+});

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -599,6 +599,15 @@ const Simulator = ({worker, initialState, appInsights}) => {
         : prefersDarkMode
           ? 'dark'
           : 'light';
+
+  // Mirror the resolved palette mode onto the root <html> element so that
+  // static CSS rules can target `html[data-theme='dark']` instead of the OS
+  // `prefers-color-scheme` media query, which desyncs when the user forces
+  // a theme override in Settings.
+  React.useLayoutEffect(() => {
+    document.documentElement.setAttribute('data-theme', paletteMode);
+  }, [paletteMode]);
+
   // `responsiveFontSizes` rescales the MUI typography variants
   // (h1..h6, body etc.) so that text shrinks gracefully on phones
   // and tablets. Without it MUI sticks to its desktop-tuned sizes,

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -301,19 +301,9 @@ const Simulator = ({worker, initialState, appInsights}) => {
       setParsedInstructions(result.parsedInstructions);
     }
 
-    // Always mirror the worker's stdout field, including the empty string.
-    // The previous truthiness guard (`if (result.stdout)`) silently dropped
-    // empty-string updates, which left the displayed stdout stuck on the
-    // previous run's content after a reset/load and made the stdout state
-    // diverge from the worker's view of the world. A real long run (e.g.
-    // the default sample's 1000-iteration loop before its SYSCALL 5) goes
-    // through many batches where `result.stdout === ""`; under the old
-    // guard, if any later state-clearing event raced with the final batch
-    // that carried the printf output, the user would see nothing in the
-    // Standard Output panel. Reflecting the worker's value unconditionally
-    // keeps the two in lock-step. `?? ''` is purely defensive against an
-    // unexpectedly null/undefined field.
-    setStdout(result.stdout ?? '');
+    if (result.stdout) {
+      setStdout(result.stdout);
+    }
   };
 
   const updateState = (result) => {

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -301,9 +301,19 @@ const Simulator = ({worker, initialState, appInsights}) => {
       setParsedInstructions(result.parsedInstructions);
     }
 
-    if (result.stdout) {
-      setStdout(result.stdout);
-    }
+    // Always mirror the worker's stdout field, including the empty string.
+    // The previous truthiness guard (`if (result.stdout)`) silently dropped
+    // empty-string updates, which left the displayed stdout stuck on the
+    // previous run's content after a reset/load and made the stdout state
+    // diverge from the worker's view of the world. A real long run (e.g.
+    // the default sample's 1000-iteration loop before its SYSCALL 5) goes
+    // through many batches where `result.stdout === ""`; under the old
+    // guard, if any later state-clearing event raced with the final batch
+    // that carried the printf output, the user would see nothing in the
+    // Standard Output panel. Reflecting the worker's value unconditionally
+    // keeps the two in lock-step. `?? ''` is purely defensive against an
+    // unexpectedly null/undefined field.
+    setStdout(result.stdout ?? '');
   };
 
   const updateState = (result) => {

--- a/src/webapp/components/StdOut.js
+++ b/src/webapp/components/StdOut.js
@@ -1,16 +1,20 @@
 import React from 'react';
+import { useTheme } from '@mui/material/styles';
 
 const StdOut = (props) => {
+  const theme = useTheme();
   return (
-    <textarea 
-      readOnly 
-      value={props.stdout || ''} 
+    <textarea
+      readOnly
+      value={props.stdout || ''}
       id="stdout-view"
       style={{
         width: '100%',
         minHeight: '100px',
         fontFamily: 'monospace',
-        fontSize: '0.75rem'
+        fontSize: '0.75rem',
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.background.paper,
       }}
     />
   );

--- a/src/webapp/static/style.css
+++ b/src/webapp/static/style.css
@@ -217,32 +217,33 @@ div.error-accordion {
   }
 }
 
-/* Dark Mode Specific Styles */
-@media screen and (prefers-color-scheme: dark) {
-  #right-panel {
-    border-left-color: rgba(255, 255, 255, 0.188);
-  }
+/* Dark Mode Specific Styles
+   Driven by the app's resolved theme (the data-theme attribute set on <html>
+   from the MUI palette mode), NOT the OS `prefers-color-scheme` media query,
+   so these stay in sync when the user overrides the theme in Settings. */
+html[data-theme='dark'] #right-panel {
+  border-left-color: rgba(255, 255, 255, 0.188);
+}
 
-  div.error-accordion{
-    border-bottom-color: rgba(255, 255, 255, 0.188);
-  }
+html[data-theme='dark'] div.error-accordion {
+  border-bottom-color: rgba(255, 255, 255, 0.188);
+}
 
-  @media (max-width: 900px) {
-    #right-panel {
-      border-top-color: rgba(255, 255, 255, 0.188);
-    }
+@media (max-width: 900px) {
+  html[data-theme='dark'] #right-panel {
+    border-top-color: rgba(255, 255, 255, 0.188);
   }
+}
 
-  textarea {
-    background: transparent;
-    color: white;
-  }
+html[data-theme='dark'] textarea {
+  background: transparent;
+  color: white;
+}
 
-  ::-webkit-scrollbar {
-    background-color: #1e1e1e;
-  }
+html[data-theme='dark'] ::-webkit-scrollbar {
+  background-color: #1e1e1e;
+}
 
-  ::-webkit-scrollbar-thumb {
-    background-color: rgb(97, 97, 97);
-  }
+html[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background-color: rgb(97, 97, 97);
 }


### PR DESCRIPTION
## Fix: raw-element styles (stdout/scrollbars/borders) now follow the app theme, not the OS

### Problem

The CSS dark-mode block for raw HTML elements was gated on the OS `prefers-color-scheme: dark` media query, which desyncs from the user-selected MUI theme when the user overrides the theme in Settings:

- **OS=dark, app=light** → `textarea { color: white }` from the media query fires → white text on a light background (invisible). This was the originally reported bug.
- **OS=light, app=dark** → the media query does NOT fire → dark text on a dark background (invisible in the opposite direction).

Panel borders and scrollbars had the same desync problem.

### Root cause

```css
/* OLD — fires based on OS, not app theme */
@media screen and (prefers-color-scheme: dark) {
  textarea { color: white; }
  /* ... borders, scrollbars ... */
}
```

### Fix

**Two parts:**

1. **`Simulator.js`** — added a `React.useLayoutEffect` that mirrors the resolved `paletteMode` (`'light'|'dark'`) onto `document.documentElement` as a `data-theme` attribute. This runs before paint (avoiding a flash-of-wrong-theme) and updates whenever the user switches themes.

2. **`style.css`** — replaced the `@media prefers-color-scheme: dark` block with equivalent `html[data-theme='dark']` rules. The textarea, panel borders, and scrollbars now follow the **app's resolved palette**, not the OS.

```css
/* NEW — follows the app theme */
html[data-theme='dark'] textarea { background: transparent; color: white; }
html[data-theme='dark'] #right-panel { border-left-color: rgba(255,255,255,0.188); }
/* ... etc. */
```

**`StdOut.js`** keeps its MUI `useTheme()` inline styles as defense-in-depth (ensures the textarea exactly matches the MUI palette). Both mechanisms are complementary.

The `useMediaQuery('(prefers-color-scheme: dark)')` calls in `Simulator.js` and `Code.js` are left untouched — they are the correct fallback for `themeMode === 'auto'`.

### Tests

Two regression directions in `sample-program-stdout.spec.js`:

| Scenario | OS | App theme | Expected text | Result |
|---|---|---|---|---|
| Original bug | dark | light (forced) | Dark (luminance < 150) | ✅ |
| Opposite direction | light | dark (forced) | Light (luminance > 150) | ✅ |

The second test also asserts `document.documentElement.getAttribute('data-theme') === 'dark'`, confirming the `data-theme` bridge is in place.
