### PR TITLE
Slim Monaco bundle to make web UI output compact (#1273)

### DIFF
--- a/.github/scripts/test_deploy_web_pages.py
+++ b/.github/scripts/test_deploy_web_pages.py
@@ -568,3 +568,61 @@ def test_candidate_die_on_missing_artifact(tmp_path):
         assert exc_info.value.code == 1
     finally:
         os.chdir(old)
+
+
+# ---------------------------------------------------------------------------
+# §6.1 Test 9 (issue #1273): promote replaces root cleanly, leaving no stale
+# files from the previous build. This guards the "push files cleanly, keeping
+# only the ones needed for the current version" guarantee.
+# ---------------------------------------------------------------------------
+
+
+def test_promote_removes_stale_root_files(tmp_path):
+    pages = tmp_path / "pages"
+    pages.mkdir()
+
+    # First promote: seed the root with "version 1" build files, including
+    # several numbered chunk files that mimic webpack output.
+    art1 = tmp_path / "art1"
+    art1.mkdir()
+    (art1 / "index.html").write_text("v1")
+    (art1 / "ui.js").write_text("v1 main")
+    for chunk in ("111.ui.js", "222.ui.js", "333.ui.js"):
+        (art1 / chunk).write_text("v1 chunk")
+    (art1 / "old-asset").mkdir()
+    (art1 / "old-asset" / "logo.png").write_text("v1 logo")
+    promote(pages, art1, 1)
+
+    # Sanity: the v1 chunk files and asset dir are in the root after promote.
+    for stale in ("111.ui.js", "222.ui.js", "333.ui.js", "old-asset"):
+        assert (pages / stale).exists(), f"{stale} should exist after v1 promote"
+
+    # Second promote: "version 2" build with a completely different set of
+    # numbered chunks. None of the v1 chunks/assets exist in this artifact.
+    art2 = tmp_path / "art2"
+    art2.mkdir()
+    (art2 / "index.html").write_text("v2")
+    (art2 / "ui.js").write_text("v2 main")
+    for chunk in ("444.ui.js", "555.ui.js"):
+        (art2 / chunk).write_text("v2 chunk")
+    promote(pages, art2, 2)
+
+    # (a) Every stale v1-only file/dir must be gone from the root.
+    for stale in ("111.ui.js", "222.ui.js", "333.ui.js", "old-asset"):
+        assert not (pages / stale).exists(), (
+            f"stale file {stale} from v1 must be removed on v2 promote (issue #1273)"
+        )
+
+    # (b) The root must contain exactly the current (v2) artifact's prod files.
+    assert (pages / "444.ui.js").is_file()
+    assert (pages / "555.ui.js").is_file()
+    assert (pages / "index.html").read_text() == "v2"
+    assert (pages / "ui.js").read_text() == "v2 main"
+
+    # (c) Reserved infrastructure and the immutable version snapshots survive.
+    assert (pages / "manifest.json").is_file()
+    assert (pages / "v" / "1").is_dir()
+    assert (pages / "v" / "2").is_dir()
+    assert (pages / "prev").is_dir()
+    assert (pages / "CNAME").is_file()
+    assert (pages / ".nojekyll").is_file()

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -4,7 +4,7 @@ import { initVimMode } from 'monaco-vim';
 // new
 import MonacoEditor from 'react-monaco-editor';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import * as monacoEditor from 'monaco-editor';
+import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
 // Resolve the Monaco editor theme name from the MUI palette mode passed in
 // by the parent (which already accounts for the user's THEME_MODE setting).

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,12 @@ const versionsPlugin = new webpack.DefinePlugin({
   VERSION: JSON.stringify(grPlugin.version().replace(/^v/, '')),
 });
 const monacoPlugin = new MonacoWebpackPlugin({
-  languages: ['mips'],
+  // The app registers its own custom 'mips' Monarch grammar and tokens-provider
+  // factory in Code.js, deliberately replacing monaco's stock mips contribution
+  // (see the comments there about the tokenization race). Loading no built-in
+  // languages keeps the bundle minimal and avoids that race entirely. The core
+  // editor worker is still emitted regardless of this list.
+  languages: [],
   features: ['comment', 'foldng', 'hover'],
 });
 
@@ -45,6 +50,16 @@ module.exports = (env, argv) => {
     // Use an external source map in production and keep fast inline maps
     // only for development.
     devtool: isProduction ? 'source-map' : 'inline-source-map',
+    resolve: {
+      alias: {
+        // Force react-monaco-editor and monaco-vim to resolve the bare
+        // 'monaco-editor' import to the core editor API instead of the full
+        // package entry (editor.main), which eagerly bundles ~100 unused
+        // language grammars and the JSON/CSS/HTML/TS language services. The
+        // app only uses the core editor plus its own custom 'mips' grammar.
+        'monaco-editor$': 'monaco-editor/esm/vs/editor/editor.api',
+      },
+    },
     output: {
       path: outputPath,
       filename: 'ui.js',


### PR DESCRIPTION
## Summary

Fixes #1273 by making the web UI build output dramatically more compact.

The build emitted **~87 `*.ui.js` chunks (275 files in `out/web`)** because
`Code.js` did `import * as monacoEditor from 'monaco-editor'`, which eagerly
bundles the **entire** Monaco package: ~100 unused language grammars (solidity,
abap, pgsql, ruby, sql, …) plus the full JSON/HTML/CSS/TypeScript language
services and their workers. The app only needs the core editor and its own
custom `mips` Monarch grammar.

## Changes

- **`src/webapp/components/Code.js`** — import the slim
  `monaco-editor/esm/vs/editor/editor.api` instead of the full package.
- **`webpack.config.js`** — add `resolve.alias` for `monaco-editor$` so
  `react-monaco-editor` and `monaco-vim` resolve to the slim API too; set
  `MonacoWebpackPlugin` `languages: []` (the app registers its own `mips`
  grammar, deliberately replacing the stock one — see the comments in
  `Code.js`), keeping only the core editor worker.
- **`.github/scripts/test_deploy_web_pages.py`** — add
  `test_promote_removes_stale_root_files`, a regression test asserting a
  `promote` removes stale root files, locking in the clean-push guarantee
  behind #1273.

## Results

| metric | before | after |
|---|--:|--:|
| `*.ui.js` chunk files | 87 | **6** |
| files in `out/web` | 275 | **29** |
| `ui.js` | 4.99 MB | 4.04 MB |
| total JS (no maps) | 6.21 MB | **4.71 MB** (-24%) |

## Validation

- Playwright suite passes, including `editor-persistence` and the #1723
  `syntax-highlighting-during-run` test that exercises the exact Monaco
  tokenization path touched here.
- Deploy-script tests: **16/16** (15 existing + new clean-push regression test).
- Prettier-clean edits; no new lint issues.

## Notes

- Separately verified the live `web.edumips.org` root is already clean (matches
  the current `v/5/` snapshot exactly) — the promote/candidate/rollback system
  already prevents stale-file litter. This PR shrinks the *legitimate*
  per-version footprint that gets pushed.
- Out of scope (optional follow-ups): `optimization.splitChunks` tuning and
  emitting chunks into an `assets/` subdir to further tidy the Pages-repo root.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
