### PR TITLE
fix(web): auto-migrate Pages repo to unified versioning layout

### DIFF
--- a/.github/scripts/migrate-pages-if-needed.sh
+++ b/.github/scripts/migrate-pages-if-needed.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Self-healing, one-shot migration of the web.edumips.org Pages repo from the
+# legacy layout (manifest.json + candidates.json + /v/<n>/ + date dirs + prev/)
+# to the unified layout (versions.json + /c/<sha>/). See
+# docs/design/unified-web-versioning.md.
+#
+# It is idempotent and safe to call from every Pages-writing workflow
+# (push-web, promote-web, rollback-web):
+#   - If versions.json already exists, the repo is migrated; do nothing.
+#   - If there are no legacy index files either, it is a fresh repo; do nothing
+#     (the caller's push/promote will create versions.json on its own).
+#   - Otherwise run `deploy-web-pages.py migrate` once and push the result so
+#     the very next push/promote/rollback operates on the unified layout.
+#
+# Usage: migrate-pages-if-needed.sh <pages-repo-dir> <edumips64-repo-dir>
+#   <pages-repo-dir>     working clone of EduMIPS64/web.edumips.org (push remote
+#                        already authenticated)
+#   <edumips64-repo-dir> full-history checkout of this repo, used by `migrate`
+#                        to compute seq = `git rev-list --count <sha>`
+set -euo pipefail
+
+PAGES_DIR="${1:?pages repo dir required}"
+EDUMIPS_DIR="${2:?edumips64 repo dir required}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "${PAGES_DIR}/versions.json" ]]; then
+  echo "versions.json present — Pages repo already on the unified layout."
+  exit 0
+fi
+
+if [[ ! -f "${PAGES_DIR}/manifest.json" && ! -f "${PAGES_DIR}/candidates.json" ]]; then
+  echo "No versions.json and no legacy index files — fresh repo, nothing to migrate."
+  exit 0
+fi
+
+echo "Legacy layout detected (no versions.json) — running one-shot migration."
+cp "${SCRIPT_DIR}/deploy-web-pages.py" "${PAGES_DIR}/"
+( cd "${PAGES_DIR}" && python3 deploy-web-pages.py migrate --repo "${EDUMIPS_DIR}" )
+rm -f "${PAGES_DIR}/deploy-web-pages.py"
+
+cd "${PAGES_DIR}"
+git add -A
+if git diff --cached --quiet; then
+  echo "Migration produced no changes."
+  exit 0
+fi
+git commit -m "Migrate web.edumips.org to unified versioning layout"
+git push origin master
+echo "Pushed unified-versioning migration."

--- a/.github/workflows/promote-web.yml
+++ b/.github/workflows/promote-web.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Checkout edumips64 (for script)
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Full history so the one-shot legacy migration can compute
+          # seq = `git rev-list --count <sha>` for past promoted builds.
+          fetch-depth: 0
 
       - name: Clone Pages repo
         env:
@@ -51,6 +53,9 @@ jobs:
             pages-repo --branch master --depth 1
           git -C pages-repo config user.name "github-actions[bot]"
           git -C pages-repo config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Migrate legacy Pages layout if needed
+        run: .github/scripts/migrate-pages-if-needed.sh pages-repo "${{ github.workspace }}"
 
       - name: Resolve SHA to promote
         id: resolve

--- a/.github/workflows/push-web.yml
+++ b/.github/workflows/push-web.yml
@@ -102,6 +102,9 @@ jobs:
           git -C pages-repo config user.name "github-actions[bot]"
           git -C pages-repo config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Migrate legacy Pages layout if needed
+        run: .github/scripts/migrate-pages-if-needed.sh pages-repo "${{ github.workspace }}"
+
       - name: Run push script
         env:
           HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}

--- a/.github/workflows/rollback-web.yml
+++ b/.github/workflows/rollback-web.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Checkout edumips64 (for script)
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Full history so the one-shot legacy migration can compute
+          # seq = `git rev-list --count <sha>` for past promoted builds.
+          fetch-depth: 0
 
       - name: Clone Pages repo
         env:
@@ -36,6 +38,9 @@ jobs:
             pages-repo --branch master --depth 1
           git -C pages-repo config user.name "github-actions[bot]"
           git -C pages-repo config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Migrate legacy Pages layout if needed
+        run: .github/scripts/migrate-pages-if-needed.sh pages-repo "${{ github.workspace }}"
 
       - name: Run rollback script
         run: |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -529,8 +529,18 @@ dirs, and `/prev/`. A one-shot `deploy-web-pages.py migrate [--repo PATH]
 [--dry-run]` converts it: it computes `seq` for each SHA, moves the old
 directories to `/c/<sha>/`, synthesizes `versions.json`, leaves `/v/<n>/`
 redirect stubs (kept one release cycle), and deletes the legacy index files,
-`prev/`, and the date dirs. Run it once against a full clone of the Pages repo
-with `--dry-run` first.
+`prev/`, and the date dirs.
+
+This migration is **self-healing** and runs automatically. Every Pages-writing
+workflow (`push-web`, `promote-web`, `rollback-web`) invokes
+`.github/scripts/migrate-pages-if-needed.sh` right after cloning the Pages
+repo. The helper is idempotent: it runs `migrate` (and commits the result) only
+when `versions.json` is absent but legacy index files are present, and is a
+no-op once the repo is on the unified layout (or on a fresh, empty repo). This
+is why those three workflows check out the edumips64 repo with `fetch-depth: 0`
+— `migrate` needs full history to compute `seq` for past promoted builds. To
+preview the conversion manually, run `migrate --repo <full-clone> --dry-run`
+against a clone of the Pages repo.
 
 
 ### Manual release checklist


### PR DESCRIPTION
## Problem

PR #1849 switched web.edumips.org to the **unified** versioning model
(`versions.json` + `/c/<sha>/`), but the **live Pages repo was never migrated**
from the legacy layout (`manifest.json` + `candidates.json` + `/v/<n>/` + date
dirs + `prev/`). The first `promote-web` dispatch after the merge therefore
crashed:

```
File "<stdin>", line 2, in <module>
FileNotFoundError: [Errno 2] No such file or directory: 'versions.json'
```

(the "Resolve SHA to promote" step does `json.load(open('versions.json'))`).

## Fix

Make the deploy pipeline **self-healing**. New
`.github/scripts/migrate-pages-if-needed.sh` is a guarded, idempotent wrapper
around `deploy-web-pages.py migrate`. It is invoked by `push-web`,
`promote-web`, and `rollback-web` immediately after cloning the Pages repo, and:

- runs the one-shot migration **and commits/pushes it** only when
  `versions.json` is absent but legacy index files are present;
- is a **no-op** once the repo is on the unified layout;
- is a **no-op** on a fresh, empty repo (the caller's push/promote creates
  `versions.json`).

Because `migrate` computes `seq = git rev-list --count <sha>` for past promoted
builds, `promote-web` and `rollback-web` are bumped to `fetch-depth: 0`
(`push-web` already checks out full history). The developer guide documents the
self-healing behavior.

## Validation

Tested end to end against a real clone of `EduMIPS64/web.edumips.org`:

- Migration produces `versions.json` with the 5 promoted builds (current =
  `a08b8d56`), moves each to `/c/<sha>/`, leaves `/v/1..5/` redirect stubs, and
  removes `manifest.json`, `candidates.json`, `prev/`, and the `2026-06-14`
  date dir — leaving a clean root (`c/`, `v/`, `versions.json` only).
- The lone candidate (same SHA as the current promoted build) is correctly
  deduped → 0 pending candidates.
- Helper is idempotent on re-run and a no-op on a fresh repo.
- A subsequent explicit promote of an older promoted SHA (rollback-style)
  succeeds and preserves the keep-invariant.
- `deploy-web-pages.py` unit suite: 19/19 pass (script unchanged).

After this merges, the next `push-web` / `promote-web` / `rollback-web` run will
migrate the live Pages repo automatically; promoting the newest candidate then
works as designed.
