### PR TITLE
ci(web): publish web candidate on every master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,28 @@
 name: CI Build
 
-# This is the "untrusted" stage of the CI pipeline. It runs on pull requests
-# (including those from forks) with a read-only token and NO access to secrets.
-# It builds and tests the proposed code, publishes coverage to the run's job
+# This is the "untrusted" stage of the CI pipeline. On pull requests (including
+# those from forks) it runs with a read-only token and NO access to secrets: it
+# builds and tests the proposed code, publishes coverage to the run's job
 # summaries, and uploads the build outputs as artifacts.
 #
-# The only privileged action (deploying a preview build) is handled by the
-# separate `pr-reports.yml` workflow, which runs base-branch code only and
-# never checks out pull request code. This separation means that code from a
-# fork can be built and tested safely without ever being able to reach
+# On pull requests the only privileged action (deploying a preview build) is
+# handled by the separate `pr-reports.yml` workflow, which runs base-branch code
+# only and never checks out pull request code. This separation means that code
+# from a fork can be built and tested safely without ever being able to reach
 # repository secrets or a write-enabled token.
+#
+# On `push` to `master` and on the nightly `schedule` (both of which can only run
+# trusted, already-merged code — a fork cannot trigger them on this repo) one
+# extra job runs: `publish-web-candidate`. It depends only on `build-web`, so the
+# freshly built web app is published as a per-commit candidate to
+# web.edumips.org as soon as the (fast) web build finishes, in parallel with the
+# slow desktop/snap/electron builds. That job — and only that job — is granted
+# the `PAT_WEBUI` secret (via the reusable `push-web.yml` workflow); it is gated
+# to `master` push/schedule events so it never runs for pull requests or forks.
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
@@ -23,7 +35,8 @@ permissions:
 
 jobs:
   # Detect which files changed in the PR to conditionally run expensive builds.
-  # On schedule runs, all outputs are set to 'true' so every build runs.
+  # On schedule and push-to-master runs, all outputs are set to 'true' so every
+  # build runs (a merged master commit always gets the full pipeline).
   detect-changes:
     name: Detect file changes
     runs-on: ubuntu-latest
@@ -31,8 +44,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      snap: ${{ github.event_name == 'schedule' && 'true' || steps.changes.outputs.snap }}
-      electron: ${{ github.event_name == 'schedule' && 'true' || steps.changes.outputs.electron }}
+      snap: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'true' || steps.changes.outputs.snap }}
+      electron: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'true' || steps.changes.outputs.electron }}
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
@@ -65,6 +78,29 @@ jobs:
     uses: ./.github/workflows/build-web.yml
     with:
       ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+  # Publish the freshly built web app as a per-commit candidate to
+  # web.edumips.org. Runs ONLY on master push/schedule events (never on pull
+  # requests or forks), and depends solely on `build-web` so the candidate goes
+  # live as soon as the web build finishes — in parallel with the slow
+  # desktop/snap/electron jobs. The privileged publish logic (and the PAT_WEBUI
+  # secret) lives in the reusable `push-web.yml` workflow; it is reused here and
+  # also runnable on its own via workflow_dispatch. See
+  # docs/design/unified-web-versioning.md.
+  publish-web-candidate:
+    name: Publish web candidate
+    needs: build-web
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      (github.event_name == 'push' || github.event_name == 'schedule')
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/push-web.yml
+    with:
+      run_id: ${{ github.run_id }}
+      head_sha: ${{ github.sha }}
+    secrets: inherit
 
   # Run web UI Playwright tests locally with Istanbul coverage instrumentation.
   # The coverage report is rendered as a Markdown table and published to this

--- a/.github/workflows/push-web.yml
+++ b/.github/workflows/push-web.yml
@@ -1,15 +1,28 @@
 name: Push Web Build
 
-# Publishes every successful master CI build as a per-commit candidate at
+# Publishes every master commit's web build as a per-commit candidate at
 # /c/<sha>/ on web.edumips.org and indexes it in versions.json. It never
 # touches the production root — that only changes on an explicit promotion
 # (see promote-web.yml). See docs/design/unified-web-versioning.md.
+#
+# This is a reusable workflow. It is invoked in two ways:
+#   - workflow_call: from ci.yml's `publish-web-candidate` job on every master
+#     push/schedule, right after the `build-web` job, reusing the web artifact
+#     that CI just built (passed via run_id + head_sha).
+#   - workflow_dispatch: manually, to (re)publish the latest successful master
+#     CI build as a candidate.
 
 on:
-  workflow_run:
-    workflows: ["CI Build"]
-    types: [completed]
-    branches: [master]
+  workflow_call:
+    inputs:
+      run_id:
+        description: 'CI run id that produced the web artifact to publish.'
+        required: true
+        type: string
+      head_sha:
+        description: 'Full commit SHA the artifact was built from.'
+        required: true
+        type: string
   workflow_dispatch:
 
 concurrency:
@@ -20,9 +33,8 @@ jobs:
   push:
     name: Push candidate build
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'master')
+      inputs.run_id != '' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,9 +52,15 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ -n "${INPUT_RUN_ID}" ]]; then
+            # Reused from ci.yml: the web artifact lives in the calling CI run.
+            RUN_ID="${INPUT_RUN_ID}"
+            HEAD_SHA="${INPUT_HEAD_SHA}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual: find latest successful CI Build on master
             RUN_JSON=$(gh run list \
               --workflow ci.yml \
@@ -59,9 +77,8 @@ jobs:
             RUN_ID=$(echo "$RUN_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['databaseId'])")
             HEAD_SHA=$(echo "$RUN_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['headSha'])")
           else
-            # workflow_run trigger
-            RUN_ID="${{ github.event.workflow_run.id }}"
-            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "ERROR: no run context (expected workflow_call inputs or workflow_dispatch)"
+            exit 1
           fi
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"

--- a/docs/design/unified-web-versioning.md
+++ b/docs/design/unified-web-versioning.md
@@ -173,7 +173,11 @@ Three subcommands replace today's `promote` / `candidate` / `rollback`.
 
 ### `push <artifact_dir> <sha> <seq> <build> <targetRelease>`
 
-Runs on **every** successful master CI build (ungated).
+Runs on **every** master commit — it is a `ci.yml` job (`publish-web-candidate`)
+that depends only on `build-web`, so it publishes as soon as the web build
+finishes (in parallel with the slow desktop/snap/electron jobs), plus a nightly
+schedule and a manual `workflow_dispatch` fallback. The privileged logic lives
+in the reusable `push-web.yml` workflow.
 
 1. If `/c/<sha>/` already exists (CI re-run) → idempotent no-op for the files.
 2. Copy the artifact into `/c/<sha>/` (immutable snapshot).
@@ -288,7 +292,7 @@ All version metadata now comes from **one** `versions.json` fetch.
 
 | File | Today | After |
 |------|-------|-------|
-| `candidate-web.yml` → **`push-web.yml`** | deploys candidate to date dir, updates `candidates.json` | computes `seq = git rev-list --count <sha>`, runs `push` → `/c/<sha>/`, updates `versions.json`. Still ungated, still `workflow_run` on CI success + `workflow_dispatch`. |
+| `candidate-web.yml` → **`push-web.yml`** | deploys candidate to date dir, updates `candidates.json` | computes `seq = git rev-list --count <sha>`, runs `push` → `/c/<sha>/`, updates `versions.json`. Now a **reusable workflow** (`workflow_call`) invoked by `ci.yml`'s `publish-web-candidate` job on every master push/schedule (right after `build-web`), plus `workflow_dispatch`. |
 | `promote-web.yml` | has a **`build` job** (fresh-mode) + downloads artifact + promotes | **`build` job removed**. Input: `sha` (full or short; default = **newest candidate** in `versions.json`). Verifies `/c/<sha>/` exists in Pages, runs `promote`. No artifact download, no webpack. Still gated to maintainer + master. |
 | `rollback-web.yml` | swaps `root` ↔ `prev/` | runs `rollback` (newest promoted below current) or `promote <prev promoted sha>`. Gated. |
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -53,19 +53,27 @@ This project uses GitHub Actions for continuous integration
 
 There are five main CI/CD workflows:
 
-- **CI Build** (`ci.yml`) — runs on every pull request and on a daily schedule.
-  Builds and tests the desktop application, builds the web application, runs the
-  web UI tests, and builds/tests the Snap package. It runs with a read-only
-  token and no access to secrets, so it can safely build code from forks.
+- **CI Build** (`ci.yml`) — runs on every pull request, on every push to
+  `master`, and on a daily schedule. Builds and tests the desktop application,
+  builds the web application, runs the web UI tests, and builds/tests the Snap
+  and Electron packages. On pull requests it runs with a read-only token and no
+  access to secrets, so it can safely build code from forks. On master
+  push/schedule events one extra job, `publish-web-candidate`, runs: it reuses
+  `push-web.yml` (with the `PAT_WEBUI` secret) to publish the just-built web app
+  as a candidate. That job is gated to `master` push/schedule events so secrets
+  are never exposed to pull-request or fork builds.
   All CI checkouts use `fetch-depth: 0` so `git describe` works correctly.
 - **PR preview deploy** (`pr-reports.yml`) — triggered when a CI Build run
   completes. It runs from the base branch (never checking out pull request
   code) and deploys the pre-built web application to the staging environment.
-- **Push web build** (`push-web.yml`) — triggered when a CI Build run completes
-  successfully on `master`. Publishes the build as a per-commit candidate to
-  `web.edumips.org` at `/c/<full-sha>/` and indexes it in `versions.json`. It
-  never touches the production root. Users can browse and share these builds
-  from the web UI's **About** tab. See the
+- **Push web build** (`push-web.yml`) — a **reusable** workflow invoked by
+  `ci.yml`'s `publish-web-candidate` job on every master push (and the nightly
+  schedule), right after the web build finishes — so the candidate goes live in
+  parallel with the slow desktop/snap/electron builds. It can also be run
+  manually via `workflow_dispatch`. Publishes the build as a per-commit
+  candidate to `web.edumips.org` at `/c/<full-sha>/` and indexes it in
+  `versions.json`. It never touches the production root. Users can browse and
+  share these builds from the web UI's **About** tab. See the
   [Unified web versioning](#unified-web-versioning) section below for details.
 - **Release** (`release.yml`) — runs on every push to `master` to build all
   release artifacts (JAR, MSI, Electron apps). The `deploy-prod` job is
@@ -493,10 +501,11 @@ tested in `test_deploy_web_pages.py` (`cd .github/scripts && python -m pytest`).
 
 #### Operations
 
-- **push** (`push-web.yml`) — runs on every successful master CI build. Copies
-  the artifact to `/c/<sha>/`, adds a `promoted: false` entry, and **never
-  touches the root or prunes**. Idempotent on CI re-runs. Computes `seq` and the
-  build string from a full-history checkout (`fetch-depth: 0`).
+- **push** (`push-web.yml`) — runs on every master commit (a `ci.yml` job
+  reuses it right after the web build; also runnable via `workflow_dispatch`).
+  Copies the artifact to `/c/<sha>/`, adds a `promoted: false` entry, and
+  **never touches the root or prunes**. Idempotent on CI re-runs. Computes `seq`
+  and the build string from a full-history checkout (`fetch-depth: 0`).
 - **promote** (`promote-web.yml`) — manual, gated to `lupino3` on `master`.
   Input `sha` is a full or short SHA of an **already-pushed** candidate; leave
   it empty to promote the **newest** candidate. The workflow verifies


### PR DESCRIPTION
## Why

The unified web-versioning pipeline only published per-commit candidates from the **nightly `CI Build` cron** (`push-web.yml` triggered via `workflow_run`). Consequences:

- Merged master commits did not become promotable candidates until the next day.
- Right after the unified-versioning migration there were **zero pending candidates**, so **Promote Web to Production** failed with `ERROR: no pending candidates to promote` ([run](https://github.com/EduMIPS64/edumips64/actions/runs/27498678696)).

This also contradicted the design intent: *"every master version should be pushed to a directory with the commit ID."*

## What

Build on **every push to master** and publish the web candidate **as soon as the fast web build finishes**, in parallel with the slow desktop/snap/electron builds (so the web goes live as a candidate first, the heavy artifacts follow).

- **`ci.yml`**
  - Add a `push: branches: [master]` trigger.
  - Force the full build matrix (snap/electron) on push/schedule events.
  - Add a `publish-web-candidate` job that `needs: build-web` and is gated to `master` push/schedule events. It reuses `push-web.yml` (with `PAT_WEBUI`) to publish the candidate. The secret is **never** exposed to pull-request/fork builds — that job simply doesn't run on those events.
- **`push-web.yml`**
  - Convert to a **reusable workflow** (`workflow_call` with `run_id` + `head_sha` inputs).
  - Drop the `workflow_run` trigger (now redundant — `ci.yml` calls it directly after `build-web`).
  - Keep `workflow_dispatch` for manual re-push (resolves the latest successful master CI build).
- Document the new flow in `docs/design/unified-web-versioning.md` and `docs/developer-guide.md`.

## Security model

The "untrusted" CI stage stays secret-free for PRs/forks. The only privileged job (`publish-web-candidate`) runs **only** on `master` push/schedule events, which a fork cannot trigger on this repo. Updated the `ci.yml` header comment to document this.

## Validation

- `actionlint` clean on `ci.yml` + `push-web.yml`.
- Deploy-script pytest: 19 passed.
- End-to-end: once merged, the next master commit publishes a candidate to `/c/<sha>/`, after which `promote-web.yml` (default = newest candidate) can promote it. I'll verify the full promote on master.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
