### PR TITLE
fix(web): restore full-height help dialog under MUI v9

### DIFF
--- a/src/test/webapp/help-dialog.spec.js
+++ b/src/test/webapp/help-dialog.spec.js
@@ -14,15 +14,22 @@ test('help dialog shows embedded documentation with navigation', async ({ page }
   // Wait for the help dialog to appear
   await page.waitForSelector('.help-title');
 
-  // The dialog must use most of the viewport height for readability (it is
-  // styled to 90vh via slotProps.paper). Guard against regressions such as the
-  // MUI v9 `PaperProps` removal, which collapsed the dialog to its content
-  // height (~2/5 of the viewport).
-  const paperHeightRatio = await page.evaluate(() => {
+  // The dialog must use most of the viewport for readability: it is styled to
+  // 90vh tall and (near) full width via slotProps.paper. Guard against
+  // regressions such as the MUI v9 `PaperProps` removal (which collapsed the
+  // height to the content's ~2/5 of the viewport) and a `width: 'auto'` Paper
+  // override (which shrank the manual to less than half the viewport width).
+  const paperDims = await page.evaluate(() => {
     const paper = document.querySelector('.MuiDialog-paper');
-    return paper ? paper.getBoundingClientRect().height / window.innerHeight : 0;
+    if (!paper) return { height: 0, width: 0 };
+    const rect = paper.getBoundingClientRect();
+    return {
+      height: rect.height / window.innerHeight,
+      width: rect.width / window.innerWidth,
+    };
   });
-  expect(paperHeightRatio).toBeGreaterThan(0.8);
+  expect(paperDims.height).toBeGreaterThan(0.8);
+  expect(paperDims.width).toBeGreaterThan(0.8);
 
   // Verify the dialog title
   const title = await page.textContent('.help-title');

--- a/src/test/webapp/help-dialog.spec.js
+++ b/src/test/webapp/help-dialog.spec.js
@@ -14,6 +14,16 @@ test('help dialog shows embedded documentation with navigation', async ({ page }
   // Wait for the help dialog to appear
   await page.waitForSelector('.help-title');
 
+  // The dialog must use most of the viewport height for readability (it is
+  // styled to 90vh via slotProps.paper). Guard against regressions such as the
+  // MUI v9 `PaperProps` removal, which collapsed the dialog to its content
+  // height (~2/5 of the viewport).
+  const paperHeightRatio = await page.evaluate(() => {
+    const paper = document.querySelector('.MuiDialog-paper');
+    return paper ? paper.getBoundingClientRect().height / window.innerHeight : 0;
+  });
+  expect(paperHeightRatio).toBeGreaterThan(0.8);
+
   // Verify the dialog title
   const title = await page.textContent('.help-title');
   expect(title).toContain('EduMIPS64');

--- a/src/webapp/components/HelpDialog.js
+++ b/src/webapp/components/HelpDialog.js
@@ -582,17 +582,22 @@ export default function HelpDialog(props) {
       open={props.open}
       maxWidth="xl"
       fullWidth
-      PaperProps={{
-        sx: {
-          // On phones / small tablets give the dialog the whole screen
-          // (margins waste already-scarce space); on larger screens
-          // keep the previous "almost full height" appearance.
-          height: { xs: '100vh', sm: '90vh' },
-          m: { xs: 0, sm: 4 },
-          maxHeight: { xs: '100vh', sm: 'calc(100% - 64px)' },
-          width: { xs: '100vw', sm: 'auto' },
-          maxWidth: { xs: '100vw', sm: 'calc(100% - 64px)' },
-          borderRadius: { xs: 0, sm: 1 },
+      slotProps={{
+        // MUI v9 removed `PaperProps`; the Paper slot is now styled via
+        // `slotProps.paper`. Without this the dialog collapses to its content
+        // height (~2/5 of the viewport) instead of the intended tall layout.
+        paper: {
+          sx: {
+            // On phones / small tablets give the dialog the whole screen
+            // (margins waste already-scarce space); on larger screens
+            // keep the previous "almost full height" appearance.
+            height: { xs: '100vh', sm: '90vh' },
+            m: { xs: 0, sm: 4 },
+            maxHeight: { xs: '100vh', sm: 'calc(100% - 64px)' },
+            width: { xs: '100vw', sm: 'auto' },
+            maxWidth: { xs: '100vw', sm: 'calc(100% - 64px)' },
+            borderRadius: { xs: 0, sm: 1 },
+          },
         },
       }}
     >

--- a/src/webapp/components/HelpDialog.js
+++ b/src/webapp/components/HelpDialog.js
@@ -594,7 +594,7 @@ export default function HelpDialog(props) {
             height: { xs: '100vh', sm: '90vh' },
             m: { xs: 0, sm: 4 },
             maxHeight: { xs: '100vh', sm: 'calc(100% - 64px)' },
-            width: { xs: '100vw', sm: 'auto' },
+            width: { xs: '100vw', sm: '100%' },
             maxWidth: { xs: '100vw', sm: 'calc(100% - 64px)' },
             borderRadius: { xs: 0, sm: 1 },
           },


### PR DESCRIPTION
## Problem

Opening the help window in the web UI showed the dialog (and the embedded manual) far too small:
- **Height:** only ~2/5 of the viewport.
- **Width:** less than half the viewport (~0.46), so the manual text was cramped.

## Root cause

The dialog was sized with `PaperProps={{ sx: { height: '90vh', width: ..., ... } }}`. **MUI v9 removed the `PaperProps` prop from `Dialog`** (the Paper slot is now styled via `slotProps.paper`). After the `@mui/material` v9.1.1 bump (#1838), `PaperProps` was silently ignored, so the dialog fell back to `fullWidth`/content sizing.

Migrating to `slotProps.paper` restored the height, but also activated a stale `width: 'auto'` rule in the same `sx` (previously ignored), which shrank the dialog to its content width.

## Fix

1. Migrate the Paper styling from `PaperProps={{ sx }}` to `slotProps={{ paper: { sx } }}` (restores `height: 90vh`).
2. Change the Paper width from `auto` to `100%` on desktop so the dialog fills the available width (capped by the existing `calc(100% - 64px)` margins).

## Validation

- Verified in a real browser (Playwright) at 1400×900: the dialog Paper now occupies **0.95** of viewport width and **0.9** of viewport height (was 0.46 × 0.9 after the height-only fix, and ~0.46 × 0.4 before any fix).
- Extended `help-dialog.spec.js` to assert the Paper occupies >80% of both viewport width and height.
- `npm run build` compiles cleanly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
