### PR TITLE
Web UI: performance and hygiene quick wins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,9 @@
         "lodash": "^4.17.19",
         "monaco-editor-webpack-plugin": "^7.0.0",
         "monaco-vim": "^0.4.2",
-        "node-forge": "^1.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-icons": "^5.0.0",
-        "react-monaco-editor": "^0.59.0",
-        "react-redux": "^9.0.0"
+        "react-monaco-editor": "^0.59.0"
       },
       "devDependencies": {
         "@babel/core": "8.0.1",
@@ -4095,12 +4092,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -8499,15 +8490,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -9531,15 +9513,6 @@
         "react": "^19.2.7"
       }
     },
-    "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/react-is": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
@@ -9555,29 +9528,6 @@
         "monaco-editor": "^0.52.0",
         "react": ">=16.8.0 <20.0.0",
         "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/react-redux": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
-      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-transition-group": {
@@ -11093,15 +11043,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,9 @@
     "lodash": "^4.17.19",
     "monaco-editor-webpack-plugin": "^7.0.0",
     "monaco-vim": "^0.4.2",
-    "node-forge": "^1.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.0.0",
-    "react-monaco-editor": "^0.59.0",
-    "react-redux": "^9.0.0"
+    "react-monaco-editor": "^0.59.0"
   },
   "devDependencies": {
     "@babel/core": "8.0.1",

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -222,8 +222,6 @@ const Code = (props) => {
       newStageMap.set(props.pipeline.FPMultiplier7.Line, 'FPU Muliplier (7)');
     }
     setStageMap(newStageMap);
-    console.log('decorations');
-    console.log(newDecorations);
     decorationsRef.current = editor.deltaDecorations(
       decorationsRef.current,
       newDecorations,
@@ -361,7 +359,6 @@ const Code = (props) => {
       return;
     }
 
-    console.log('Parsing errors', props.parsingErrors);
     const lines = editor.getValue().split('\n');
     const markers = props.parsingErrors
       .filter((err) => {
@@ -383,7 +380,6 @@ const Code = (props) => {
           source: 'EduMIPS64',
         };
       });
-    console.log('Markers', markers);
 
     monaco.editor.setModelMarkers(model, 'EduMIPS64', markers);
   }, [props.parsingErrors, editor, monaco]);

--- a/src/webapp/components/InputDialog.js
+++ b/src/webapp/components/InputDialog.js
@@ -55,7 +55,9 @@ const InputDialog = ({ request, onSubmit, onCancel }) => {
           autoFocus
           fullWidth
           value={value}
-          inputProps={{ maxLength: maxLength > 0 ? maxLength : undefined }}
+          slotProps={{
+            htmlInput: { maxLength: maxLength > 0 ? maxLength : undefined },
+          }}
           onChange={(event) => {
             const next =
               maxLength > 0

--- a/src/webapp/components/Settings.js
+++ b/src/webapp/components/Settings.js
@@ -144,7 +144,7 @@ const Settings = ({
                 color="primary"
                 size="small"
                 disabled={forwardingDisabled}
-                inputProps={{ 'data-testid': 'forwarding-switch' }}
+                slotProps={{ input: { 'data-testid': 'forwarding-switch' } }}
               />
             }
             label={
@@ -168,7 +168,7 @@ const Settings = ({
                 color="primary"
                 size="small"
                 disabled={delaySlotDisabled}
-                inputProps={{ 'data-testid': 'delay-slot-switch' }}
+                slotProps={{ input: { 'data-testid': 'delay-slot-switch' } }}
               />
             }
             label={

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -29,13 +29,38 @@ import { buildTheme } from '../theme';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Typography from '@mui/material/Typography';
 
-import { debounce, isEqual } from 'lodash';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import Settings from './Settings';
 import CacheConfig from "./CacheConfig";
 import { useSetting } from '../settings/useSetting';
 import { SettingKey } from '../settings/SettingKey';
 import SampleProgram from '../data/SampleProgram';
 import { deriveLogicalState } from '../simulatorState';
+
+// Styled accordion header shared by all right-panel widgets. Defined at
+// module scope on purpose: defining a styled() component inside the
+// Simulator render body would create a new component *type* on every
+// render, making React unmount and remount every accordion header each
+// time a worker message updates state.
+const AccordionSummary = styled((props) => (
+  <MuiAccordionSummary
+    expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.8rem' }} />}
+    {...props}
+  />
+))(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(141, 166, 255, 0.08)'
+      : 'rgba(53, 87, 212, 0.06)',
+  flexDirection: 'row-reverse',
+  '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+    transform: 'rotate(180deg)',
+  },
+  '& .MuiAccordionSummary-content': {
+    marginLeft: theme.spacing(1),
+  },
+}));
 
 const Simulator = ({worker, initialState, appInsights}) => {
   // The amount of steps to run in multi-step executions.
@@ -268,7 +293,6 @@ const Simulator = ({worker, initialState, appInsights}) => {
 
   worker.onmessage = (e) => {
     const result = worker.parseResult(e.data);
-    console.log('Got message from worker.', result);
     
     // For syntax check responses, only update parsing errors to avoid unnecessary re-renders
     if (result.method === 'checksyntax') {
@@ -311,8 +335,6 @@ const Simulator = ({worker, initialState, appInsights}) => {
   };
 
   const updateState = (result) => {
-    console.log('Updating state.');
-
     applyResultState(result);
 
     // TODO: cleaner handling of error types. Checking the error message is a pretty weak check.
@@ -352,7 +374,6 @@ const Simulator = ({worker, initialState, appInsights}) => {
       setRunAll(false);
       setExecuting(false);
     } else if (stepsToRun > 0) {
-      console.log('Steps left: ' + stepsToRun);
       scheduleNextBatch(() => stepCode(stepsToRun));
     } else if (runAll) {
       scheduleNextBatch(() => stepCode(INTERNAL_STEPS_STRIDE));
@@ -394,25 +415,21 @@ const Simulator = ({worker, initialState, appInsights}) => {
   // Click handlers. Decoupled from business logic to place the telemetry hooks in the right place.
   const clickRun = () => {
     appInsights.trackEvent({name: "click", properties: {action: "run"}});
-    console.log('Executing runCode');
     runCode()
   }
 
   const clickStep = (n) => {
     appInsights.trackEvent({name: "click", properties: {action: "step"}});
-    console.log('Executing steps: ' + n);
     stepCode(n)
   }
 
   const clickLoad = () => {
     appInsights.trackEvent({name: "click", properties: {action: "load"}});
-    console.log('Executing loadCode');
     loadCode();
   }
 
   const clickStop = () => {
     appInsights.trackEvent({name: "click", properties: {action: "stop"}});
-    console.log('Stopping simulation');
     stopCode();
   }
 
@@ -650,25 +667,6 @@ const Simulator = ({worker, initialState, appInsights}) => {
     debouncedSyntaxCheck(code);
   };
 
-  const AccordionSummary = styled((props) => (
-    <MuiAccordionSummary
-      expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.8rem' }} />}
-      {...props}
-    />
-  ))(({ theme }) => ({
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(141, 166, 255, 0.08)'
-        : 'rgba(53, 87, 212, 0.06)',
-    flexDirection: 'row-reverse',
-    '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-      transform: 'rotate(180deg)',
-    },
-    '& .MuiAccordionSummary-content': {
-      marginLeft: theme.spacing(1),
-    },
-  }));
-
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
   // Resolve the user-selected theme mode: 'auto' defers to the OS media
@@ -732,7 +730,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
           inputRequest={inputRequest}
           multiStepCount={stepStride}
         />
-        <Grid container id="main-grid" disableEqualOverflow spacing={0}>
+        <Grid container id="main-grid" spacing={0}>
           <Grid id="left-panel" size={{ xs: 12, md: 8 }}>
             <Code
               onChangeValue={onCodeChange}
@@ -748,7 +746,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               onEditorReady={handleEditorReady}
             />
           </Grid>
-          <Grid size={{ xs: 12, md: 4 }} id="right-panel" disableEqualOverflow>
+          <Grid size={{ xs: 12, md: 4 }} id="right-panel">
             <ErrorList
               parsingErrors={parsingErrors}
               AccordionSummary={AccordionSummary}
@@ -760,7 +758,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   Stats
                   {accordionAlerts && accordionChanges.stats && <span className="accordion-change-indicator" />}
                 </Typography>
@@ -775,7 +773,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   Pipeline
                   {accordionAlerts && accordionChanges.pipeline && <span className="accordion-change-indicator" />}
                 </Typography>
@@ -790,7 +788,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   Registers
                   {accordionAlerts && accordionChanges.registers && <span className="accordion-change-indicator" />}
                 </Typography>
@@ -805,7 +803,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />} id="memory-accordion-summary">
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   Memory
                   {accordionAlerts && accordionChanges.memory && <span className="accordion-change-indicator" />}
                 </Typography>
@@ -820,7 +818,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   Standard Output
                   {accordionAlerts && accordionChanges.stdout && <span className="accordion-change-indicator" />}
                 </Typography>
@@ -835,7 +833,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: status === 'RUNNING' ? 'text.disabled' : 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: status === 'RUNNING' ? 'text.disabled' : 'primary.main' }}>
                   Cache Configuration
                 </Typography>
               </AccordionSummary>
@@ -853,7 +851,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
               disableGutters
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h7" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
                   General Settings
                 </Typography>
               </AccordionSummary>

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -30,7 +30,6 @@ const telemetryInitializer = (envelope) => {
 };
 appInsights.addTelemetryInitializer(telemetryInitializer);
 appInsights.trackPageView();
-console.log('Initialized AppInsights');
 
 // Web Worker that runs the EduMIPS64 core, built from the Java codebase.
 // Contains some syntactical sugar methods to make working with the
@@ -79,8 +78,6 @@ worker.version = version;
 
 worker.reset();
 const initializer = (evt) => {
-  console.log('Running the initializer callback');
-
   // Run this callback only once, to initialize the Simulator
   // React component which will then handle all subsequent messages.
   worker.removeEventListener('message', initializer);


### PR DESCRIPTION
First follow-up from the web UI code review — the mechanical, no-behavior-change items.

## Changes

1. **Hoist `AccordionSummary` out of the `Simulator` render body.** Defining a `styled()` component inside the component body creates a new component *type* on every render, so React was unmounting and remounting every accordion header in the right panel on each worker message — dozens of times per second during Run All. Now defined once at module scope.
2. **Per-method lodash imports** (`lodash/debounce`, `lodash/isEqual`). The bare `'lodash'` import is CommonJS and defeats tree-shaking, shipping the whole library. Production main bundle: **3.87 MiB → 3.79 MiB (−76 KB)**.
3. **Remove unused dependencies**: `react-redux`, `react-icons`, `node-forge` — referenced nowhere in the source; they only added install weight and Renovate churn. (`express` stays: it's used by `electron/express_server.js` at runtime.)
4. **Remove 13 stray `console.log` calls**, several of which fired on every worker message / pipeline decoration update during execution (logging full state JSON). `console.warn`/`error` untouched.
5. **Fix deprecated/invalid MUI API** that produced React DOM warnings in the console on every load:
   - `disableEqualOverflow` on `Grid` (removed Grid v2 API, ended up as an unknown DOM attribute),
   - `inputProps` → `slotProps.htmlInput` (TextField) / `slotProps.input` (Switch),
   - `variant="h7"` (not a real Typography variant, silently fell back to default styling) → `subtitle2` on the accordion titles.

## Verification

- Full Playwright suite: **86 passed, 1 skipped** (same as master).
- Loaded the app headlessly and confirmed the previous React DOM console warnings are gone and the UI renders identically.

No behavior change intended anywhere. Next review follow-up (separate PR): move the `worker.onmessage` assignment out of the render body and collapse the execution flags into a reducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)