### PR TITLE
Fix blank page in production web builds (dev-only jsxDEV in prod bundle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,29 @@ jobs:
           PLAYWRIGHT_TARGET_URL: 'http://localhost:8080'
         run: npx playwright test
 
+      # Guard against production-only bundle breakage: the coverage run above
+      # exercises a *development* webpack build, which cannot catch failures
+      # that only occur in the production bundle (e.g. the Babel 8 regression
+      # where dev-only jsxDEV() calls were emitted into a bundle carrying
+      # production React, blanking the page at startup). Rebuild the UI the
+      # same way the deployed candidates are built and smoke-test it.
+      - name: Build production UI bundle
+        run: npm run build
+
+      - name: Serve production bundle
+        run: python3 -m http.server 8081 --directory out/web &
+
+      - name: Wait for production server to be ready
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8081 && break || sleep 1
+          done
+
+      - name: Smoke-test production bundle
+        env:
+          PLAYWRIGHT_TARGET_URL: 'http://localhost:8081'
+        run: npx playwright test basic-tests
+
       # Upload Playwright traces, screenshots, and HTML report whenever the
       # test step fails so the failure is diagnosable without rerunning.
       - name: Upload Playwright artifacts on failure

--- a/.github/workflows/promote-web.yml
+++ b/.github/workflows/promote-web.yml
@@ -81,6 +81,54 @@ jobs:
           echo "Promoting SHA: ${SHA}"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
+      # ---- Promotion gate ----------------------------------------------
+      # Never promote a candidate that does not actually work. The candidate
+      # is already published at https://web.edumips.org/c/<sha>/, so run the
+      # basic Playwright tests against that exact, publicly-served content
+      # before touching production. This is the last line of defense against
+      # shipping a broken bundle (e.g. the Babel 8 jsxDEV regression that
+      # blanked the page at startup): even if a broken build slips through
+      # CI and gets pushed as a candidate, promotion aborts here.
+      - name: Set up Node.JS
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install JS dependencies (for the candidate smoke test)
+        run: npm install
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke-test the candidate before promotion
+        env:
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          FULL_SHA=$(cd pages-repo && python3 <<'PY'
+          import json, os, sys
+          short = os.environ['SHA']
+          d = json.load(open('versions.json'))
+          m = [v for v in d['versions'] if v['sha'].startswith(short)]
+          if len(m) != 1:
+              sys.exit('ERROR: %d versions in versions.json match %s' % (len(m), short))
+          print(m[0]['sha'])
+          PY
+          )
+          echo "Smoke-testing candidate at https://web.edumips.org/c/${FULL_SHA}/"
+          PLAYWRIGHT_TARGET_URL="https://web.edumips.org/c/${FULL_SHA}" \
+            npx playwright test basic-tests
+      # --------------------------------------------------------------------
+
       - name: Run promote script (never builds)
         env:
           SHA: ${{ steps.resolve.outputs.sha }}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,23 @@ module.exports = (env, argv) => {
     },
     module: {
       rules: [
-        { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader',
+          // Babel resolves its env from BABEL_ENV/NODE_ENV, *not* from
+          // webpack's --mode. Since Babel 8, @babel/preset-react defaults to
+          // the automatic JSX runtime and emits the development-only
+          // `jsxDEV()` calls unless the Babel env is 'production'. A
+          // `webpack --mode production` build therefore compiled dev-mode
+          // JSX while bundling production React (whose jsx-dev-runtime
+          // exports nothing), crashing the app at startup with
+          // "jsxDEV is not a function" and a blank page. Tie Babel's env to
+          // the webpack mode in production; keep the default resolution in
+          // development so `BABEL_ENV=coverage` still activates the istanbul
+          // instrumentation env from .babelrc.
+          options: isProduction ? { envName: 'production' } : {},
+        },
         // Webpack 5 enforces fully-specified ESM resolution for .mjs files,
         // which breaks extensionless imports like MUI's
         // 'react-transition-group/TransitionGroupContext' (added in @mui v9.1).


### PR DESCRIPTION
## What broke

Promoting the latest candidate to web.edumips.org today shipped a **blank page** with `Uncaught TypeError: (0, $L.jsxDEV) is not a function` in the console (production has since been rolled back to the June 17 build, `045ada34`).

## Root cause

Since the **Babel 8** upgrade, `@babel/preset-react` defaults to the automatic JSX runtime and chooses development vs production output from Babel's `envName` — which falls back to `BABEL_ENV`/`NODE_ENV`, **not** webpack's `--mode`. So `webpack --mode production`:

- compiled our JSX with the **development-only** `jsxDEV()` calls (Babel saw no `NODE_ENV`), while
- bundling **production React** (webpack defines `NODE_ENV=production` in the emitted code), whose `react/jsx-dev-runtime` exports nothing in production.

First render → `jsxDEV is not a function` → blank page. Every production build since the Babel 8 bump is affected (bisect not needed: the bug reproduces on any recent commit, including ones before #1884, which was innocent). Dev builds pair dev JSX with dev React, so they work — which is also why CI stayed green: **the Playwright suite only ever runs against a development/coverage webpack build.**

## Fix

1. `webpack.config.js`: pass `envName: 'production'` to babel-loader when webpack runs in production mode. Development builds keep Babel's default env resolution, so `BABEL_ENV=coverage` still activates the istanbul instrumentation env from `.babelrc`.
2. `promote-web.yml`: add a **promotion gate** — before the promote script runs, Playwright loads the candidate at its public `/c/<sha>/` URL and runs the basic tests against the exact content that would become production. If it does not boot, promotion aborts. This is the last line of defense: even a broken build that slips through CI and gets pushed as a candidate can no longer reach production.
3. `ci.yml`: add a **production-bundle smoke test** to the web coverage job — build with `npm run build` (exactly how deployed candidates are built), serve it on :8081, run the `basic-tests` spec against it. This would have failed loudly today.

## Verification (local)

- Production bundle: **zero** `jsxDEV` references (was crashing before the fix on the same commit), renders correctly headless.
- **Full Playwright suite passes against the production bundle**: 86 passed, 1 skipped.
- `BABEL_ENV=coverage npx webpack` still emits istanbul instrumentation (`__coverage__` present in bundle).

## Aftermath checklist

- [ ] Merge this, let `push-web` publish the new candidate.
- [ ] Verify the candidate at its `/c/<sha>/` URL, then re-promote to production.
- [ ] The already-published candidates for `f78610bf` and `f1224e60` remain broken — do not promote them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)