### PR TITLE
Web UI: worker subscription in an effect + execution state reducer

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -48,7 +48,7 @@ jobs:
           cache: 'npm'
 
       - name: Install JS dependencies
-        run: npm install
+        run: npm ci
 
       - name: Cache GWT unit cache
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Install JS dependencies
         run: npm install
 
+      - name: Run JS unit tests
+        run: npm run test:unit
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           cache: 'npm'
 
       - name: Install JS dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run JS unit tests
         run: npm run test:unit

--- a/.github/workflows/promote-web.yml
+++ b/.github/workflows/promote-web.yml
@@ -96,7 +96,7 @@ jobs:
           cache: 'npm'
 
       - name: Install JS dependencies (for the candidate smoke test)
-        run: npm install
+        run: npm ci
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,23 +12093,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "playwright": "1.61.1",
         "prettier": "3.9.4",
         "style-loader": "4.0.0",
+        "vitest": "^4.1.9",
         "webpack": "5.108.3",
         "webpack-bundle-analyzer": "5.3.0",
         "webpack-cli": "7.1.0",
@@ -1788,6 +1789,37 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -3590,6 +3622,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nevware21/ts-async": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
@@ -3626,6 +3676,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -3854,6 +3913,270 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3873,6 +4196,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -3895,6 +4228,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -4280,6 +4619,86 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -4698,6 +5117,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
@@ -5105,6 +5533,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -5608,6 +6045,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -6239,6 +6685,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6272,6 +6727,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -8033,6 +8497,255 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8128,6 +8841,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -8998,6 +9720,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "node_modules/pe-library": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
@@ -9167,9 +9895,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -9185,7 +9913,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -9812,6 +10539,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10274,6 +11034,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -10418,6 +11184,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10426,6 +11198,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -10744,6 +11522,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10759,6 +11552,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11083,6 +11885,229 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/watchpack": {
@@ -11776,6 +12801,22 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wildcard": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build-dbg": "webpack",
     "build": "webpack --mode production",
     "test": "npx playwright test",
+    "test:unit": "vitest run",
     "test:coverage": "BABEL_ENV=coverage npm run build-dbg && COVERAGE=true npx playwright test",
     "report:coverage": "nyc report --reporter=lcov --reporter=text",
     "electron": "electron electron/electron_main.js"
@@ -53,6 +54,7 @@
     "playwright": "1.61.1",
     "prettier": "3.9.4",
     "style-loader": "4.0.0",
+    "vitest": "^4.1.9",
     "webpack": "5.108.3",
     "webpack-bundle-analyzer": "5.3.0",
     "webpack-cli": "7.1.0",

--- a/src/test/webapp-unit/executionReducer.test.js
+++ b/src/test/webapp-unit/executionReducer.test.js
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for executionReducer.js
+ *
+ * These tests exercise every action in isolation and several multi-action
+ * sequences that mirror real run-control flows.  No browser or JSDOM is
+ * required: the reducer is a pure function.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { executionReducer, initialExecState } from '../../webapp/executionReducer.js';
+
+// Convenience: apply a sequence of actions to the initial state.
+function apply(...actions) {
+  return actions.reduce(executionReducer, initialExecState);
+}
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe('initialExecState', () => {
+  it('starts with all flags cleared', () => {
+    expect(initialExecState).toEqual({
+      stepsToRun: 0,
+      mustPause: false,
+      runAll: false,
+      executing: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STEP_REQUESTED
+// ---------------------------------------------------------------------------
+
+describe('STEP_REQUESTED', () => {
+  it('sets executing=true and records remaining steps', () => {
+    const state = executionReducer(initialExecState, {
+      type: 'STEP_REQUESTED',
+      stepsRemaining: 0,
+    });
+    expect(state.executing).toBe(true);
+    expect(state.stepsToRun).toBe(0);
+    expect(state.runAll).toBe(false);
+  });
+
+  it('stores non-zero stepsRemaining for multi-step batching', () => {
+    // Simulates stepCode(120): first batch dispatches 50, leaves 70 remaining.
+    const state = executionReducer(initialExecState, {
+      type: 'STEP_REQUESTED',
+      stepsRemaining: 70,
+    });
+    expect(state.stepsToRun).toBe(70);
+    expect(state.executing).toBe(true);
+  });
+
+  it('does not set runAll', () => {
+    const state = executionReducer(initialExecState, {
+      type: 'STEP_REQUESTED',
+      stepsRemaining: 0,
+    });
+    expect(state.runAll).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RUN_ALL_REQUESTED
+// ---------------------------------------------------------------------------
+
+describe('RUN_ALL_REQUESTED', () => {
+  it('sets runAll=true, executing=true, stepsToRun=0', () => {
+    const state = executionReducer(initialExecState, { type: 'RUN_ALL_REQUESTED' });
+    expect(state).toEqual({
+      stepsToRun: 0,
+      mustPause: false,
+      runAll: true,
+      executing: true,
+    });
+  });
+
+  it('preserves any pre-existing mustPause flag (edge case: pause before run lands)', () => {
+    // This edge case should not arise in normal usage, but the reducer must be
+    // safe: mustPause is spread from the previous state.
+    const stateWithPause = { ...initialExecState, mustPause: true };
+    const state = executionReducer(stateWithPause, { type: 'RUN_ALL_REQUESTED' });
+    expect(state.mustPause).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RESULT_RECEIVED — single step
+// ---------------------------------------------------------------------------
+
+describe('RESULT_RECEIVED (single step)', () => {
+  it('clears executing when single step completes (stepsToRun=0, runAll=false)', () => {
+    const running = apply(
+      { type: 'STEP_REQUESTED', stepsRemaining: 0 },
+    );
+    const done = executionReducer(running, {
+      type: 'RESULT_RECEIVED',
+      status: 'RUNNING',
+      encounteredBreak: false,
+    });
+    expect(done.executing).toBe(false);
+    expect(done.stepsToRun).toBe(0);
+    expect(done.runAll).toBe(false);
+    expect(done.mustPause).toBe(false);
+  });
+
+  it('clears all flags when program ends (status=STOPPED)', () => {
+    const running = apply({ type: 'STEP_REQUESTED', stepsRemaining: 0 });
+    const done = executionReducer(running, {
+      type: 'RESULT_RECEIVED',
+      status: 'STOPPED',
+      encounteredBreak: false,
+    });
+    expect(done).toEqual(initialExecState);
+  });
+
+  it('clears all flags when status=READY (e.g. after reset)', () => {
+    const running = apply({ type: 'STEP_REQUESTED', stepsRemaining: 0 });
+    const done = executionReducer(running, {
+      type: 'RESULT_RECEIVED',
+      status: 'READY',
+      encounteredBreak: false,
+    });
+    expect(done).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RESULT_RECEIVED — multi-step batching
+// ---------------------------------------------------------------------------
+
+describe('RESULT_RECEIVED (multi-step batching)', () => {
+  it('keeps executing=true between batches when stepsToRun > 0', () => {
+    // Simulate: stepCode(120) → first batch of 50 dispatched, 70 remaining.
+    const afterFirstBatch = apply({ type: 'STEP_REQUESTED', stepsRemaining: 70 });
+
+    // Worker returns from first batch, program still running.
+    const afterFirstResult = executionReducer(afterFirstBatch, {
+      type: 'RESULT_RECEIVED',
+      status: 'RUNNING',
+      encounteredBreak: false,
+    });
+
+    // State must keep executing=true so toolbar doesn't flash between batches.
+    expect(afterFirstResult.executing).toBe(true);
+    // The remaining steps are still in state for the component to use.
+    expect(afterFirstResult.stepsToRun).toBe(70);
+  });
+
+  it('clears executing after the final batch when stepsToRun reaches 0', () => {
+    // Three-batch sequence: 120 steps with stride=50 → batches of 50, 50, 20.
+    // Simulate via reducer: just track state transitions.
+    const batch1 = apply({ type: 'STEP_REQUESTED', stepsRemaining: 70 });
+    const result1 = executionReducer(batch1, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: false,
+    });
+    // Component reads stepsToRun=70, schedules stepCode(70).
+    const batch2 = executionReducer(result1, {
+      type: 'STEP_REQUESTED', stepsRemaining: 20,
+    });
+    const result2 = executionReducer(batch2, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: false,
+    });
+    // Component reads stepsToRun=20, schedules stepCode(20).
+    const batch3 = executionReducer(result2, {
+      type: 'STEP_REQUESTED', stepsRemaining: 0,
+    });
+    const result3 = executionReducer(batch3, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: false,
+    });
+    // Final batch: stepsToRun=0, runAll=false → executing cleared.
+    expect(result3.executing).toBe(false);
+    expect(result3.stepsToRun).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RUN_ALL — multi-result loop
+// ---------------------------------------------------------------------------
+
+describe('RESULT_RECEIVED (run-all mode)', () => {
+  it('keeps executing=true while program is running in run-all mode', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const afterResult = executionReducer(running, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: false,
+    });
+    // runAll=true → keep executing for next batch.
+    expect(afterResult.executing).toBe(true);
+    expect(afterResult.runAll).toBe(true);
+  });
+
+  it('clears all flags when program ends during run-all', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const ended = executionReducer(running, {
+      type: 'RESULT_RECEIVED', status: 'STOPPED', encounteredBreak: false,
+    });
+    expect(ended).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PAUSE_REQUESTED
+// ---------------------------------------------------------------------------
+
+describe('PAUSE_REQUESTED', () => {
+  it('sets mustPause=true without changing other flags', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const paused = executionReducer(running, { type: 'PAUSE_REQUESTED' });
+    expect(paused.mustPause).toBe(true);
+    expect(paused.runAll).toBe(true);
+    expect(paused.executing).toBe(true);
+  });
+
+  it('stops execution on next RESULT_RECEIVED when mustPause is set', () => {
+    const state = apply(
+      { type: 'RUN_ALL_REQUESTED' },
+      { type: 'PAUSE_REQUESTED' },
+    );
+    const stopped = executionReducer(state, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: false,
+    });
+    // mustPause=true → first branch of RESULT_RECEIVED → clear everything.
+    expect(stopped).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STOP
+// ---------------------------------------------------------------------------
+
+describe('STOP', () => {
+  it('clears stepsToRun, runAll; sets mustPause=true; keeps executing when no pending batch', () => {
+    // Worker is mid-step (hadPendingBatch=false) — executing must stay true
+    // until the worker's in-flight response arrives and sees mustPause=true.
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const stopped = executionReducer(running, {
+      type: 'STOP', hadPendingBatch: false,
+    });
+    expect(stopped.stepsToRun).toBe(0);
+    expect(stopped.runAll).toBe(false);
+    expect(stopped.mustPause).toBe(true);
+    expect(stopped.executing).toBe(true); // worker response will clear this
+  });
+
+  it('immediately clears executing when a batch was sleeping (hadPendingBatch=true)', () => {
+    // No worker response is coming — clear executing right now.
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const stopped = executionReducer(running, {
+      type: 'STOP', hadPendingBatch: true,
+    });
+    expect(stopped.executing).toBe(false);
+    expect(stopped.mustPause).toBe(true);
+  });
+
+  it('after STOP (mid-step), the incoming RESULT_RECEIVED clears executing', () => {
+    const afterStop = apply(
+      { type: 'RUN_ALL_REQUESTED' },
+      { type: 'STOP', hadPendingBatch: false },
+    );
+    // worker.reset() response arrives; status='READY' ≠ 'RUNNING' → first branch.
+    const final = executionReducer(afterStop, {
+      type: 'RESULT_RECEIVED', status: 'READY', encounteredBreak: false,
+    });
+    expect(final).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RESET
+// ---------------------------------------------------------------------------
+
+describe('RESET', () => {
+  it('clears stepsToRun, runAll, mustPause; keeps executing when no pending batch', () => {
+    // Unlike STOP, RESET does NOT set mustPause: the worker.reset() response
+    // will arrive with status='READY' and the RESULT_RECEIVED branch will clean up.
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const reset = executionReducer(running, {
+      type: 'RESET', hadPendingBatch: false,
+    });
+    expect(reset.stepsToRun).toBe(0);
+    expect(reset.runAll).toBe(false);
+    expect(reset.mustPause).toBe(false);
+    expect(reset.executing).toBe(true); // reset response will clear this
+  });
+
+  it('immediately clears executing when a batch was pending', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const reset = executionReducer(running, {
+      type: 'RESET', hadPendingBatch: true,
+    });
+    expect(reset.executing).toBe(false);
+  });
+
+  it('does not set mustPause (distinguishes RESET from STOP)', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const reset = executionReducer(running, { type: 'RESET', hadPendingBatch: false });
+    const stop  = executionReducer(running, { type: 'STOP',  hadPendingBatch: false });
+    expect(reset.mustPause).toBe(false);
+    expect(stop.mustPause).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INPUT_REQUESTED / INPUT_SUBMITTED
+// ---------------------------------------------------------------------------
+
+describe('INPUT_REQUESTED', () => {
+  it('pauses execution without changing runAll or stepsToRun', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const waitingForInput = executionReducer(running, { type: 'INPUT_REQUESTED' });
+    expect(waitingForInput.executing).toBe(false);
+    expect(waitingForInput.runAll).toBe(true); // preserved for later resumption
+  });
+});
+
+describe('INPUT_SUBMITTED', () => {
+  it('resumes execution', () => {
+    const waitingForInput = apply(
+      { type: 'RUN_ALL_REQUESTED' },
+      { type: 'INPUT_REQUESTED' },
+    );
+    const resumed = executionReducer(waitingForInput, { type: 'INPUT_SUBMITTED' });
+    expect(resumed.executing).toBe(true);
+  });
+
+  it('full input round-trip: run → input needed → submitted → result → done', () => {
+    const s0 = apply({ type: 'RUN_ALL_REQUESTED' });         // running
+    const s1 = executionReducer(s0, { type: 'INPUT_REQUESTED' });  // paused for input
+    expect(s1.executing).toBe(false);
+    const s2 = executionReducer(s1, { type: 'INPUT_SUBMITTED' });  // user submits
+    expect(s2.executing).toBe(true);
+    // Worker provides result; program finished after input.
+    const s3 = executionReducer(s2, {
+      type: 'RESULT_RECEIVED', status: 'STOPPED', encounteredBreak: false,
+    });
+    expect(s3).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encounteredBreak
+// ---------------------------------------------------------------------------
+
+describe('encounteredBreak', () => {
+  it('stops execution when a breakpoint is hit, even with runAll=true', () => {
+    const running = apply({ type: 'RUN_ALL_REQUESTED' });
+    const broke = executionReducer(running, {
+      type: 'RESULT_RECEIVED', status: 'RUNNING', encounteredBreak: true,
+    });
+    // encounteredBreak=true → first branch → clear all flags.
+    expect(broke).toEqual(initialExecState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown action (defensive)
+// ---------------------------------------------------------------------------
+
+describe('unknown action', () => {
+  it('returns the same state reference for unrecognised action types', () => {
+    const state = { ...initialExecState };
+    const next = executionReducer(state, { type: '__UNKNOWN__' });
+    expect(next).toBe(state);
+  });
+});

--- a/src/test/webapp-unit/simulatorState.test.js
+++ b/src/test/webapp-unit/simulatorState.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for simulatorState.js — deriveLogicalState helper.
+ *
+ * deriveLogicalState(status, executing, inputRequest) maps the three
+ * observable simulator values onto the five UI states used by the toolbar
+ * and keyboard-shortcut gating logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveLogicalState } from '../../webapp/simulatorState.js';
+
+describe('deriveLogicalState', () => {
+  describe('WAITING_FOR_INPUT', () => {
+    it('returns WAITING_FOR_INPUT when inputRequest is non-null, regardless of status', () => {
+      const req = { some: 'request' };
+      expect(deriveLogicalState('READY',   false, req)).toBe('WAITING_FOR_INPUT');
+      expect(deriveLogicalState('RUNNING', false, req)).toBe('WAITING_FOR_INPUT');
+      expect(deriveLogicalState('STOPPED', false, req)).toBe('WAITING_FOR_INPUT');
+      expect(deriveLogicalState('RUNNING', true,  req)).toBe('WAITING_FOR_INPUT');
+    });
+  });
+
+  describe('EMPTY', () => {
+    it('returns EMPTY when status=READY and no inputRequest', () => {
+      expect(deriveLogicalState('READY', false, null)).toBe('EMPTY');
+      expect(deriveLogicalState('READY', true,  null)).toBe('EMPTY');
+    });
+  });
+
+  describe('ENDED', () => {
+    it('returns ENDED when status=STOPPED and no inputRequest', () => {
+      expect(deriveLogicalState('STOPPED', false, null)).toBe('ENDED');
+      expect(deriveLogicalState('STOPPED', true,  null)).toBe('ENDED');
+    });
+  });
+
+  describe('EXECUTING', () => {
+    it('returns EXECUTING when status=RUNNING, executing=true, no inputRequest', () => {
+      expect(deriveLogicalState('RUNNING', true, null)).toBe('EXECUTING');
+    });
+  });
+
+  describe('READY', () => {
+    it('returns READY when status=RUNNING, executing=false, no inputRequest', () => {
+      // This is the "program loaded, paused between steps" state.
+      expect(deriveLogicalState('RUNNING', false, null)).toBe('READY');
+    });
+  });
+
+  describe('integration with executionReducer.executing', () => {
+    it('reflects the reducer executing flag: false → READY, true → EXECUTING', () => {
+      // Ensure deriveLogicalState works with the boolean values the reducer emits.
+      expect(deriveLogicalState('RUNNING', false, null)).toBe('READY');
+      expect(deriveLogicalState('RUNNING', true,  null)).toBe('EXECUTING');
+    });
+  });
+});

--- a/src/webapp/components/Simulator.js
+++ b/src/webapp/components/Simulator.js
@@ -37,6 +37,7 @@ import { useSetting } from '../settings/useSetting';
 import { SettingKey } from '../settings/SettingKey';
 import SampleProgram from '../data/SampleProgram';
 import { deriveLogicalState } from '../simulatorState';
+import { executionReducer, initialExecState } from '../executionReducer';
 
 // Styled accordion header shared by all right-panel widgets. Defined at
 // module scope on purpose: defining a styled() component inside the
@@ -256,18 +257,17 @@ const Simulator = ({worker, initialState, appInsights}) => {
     }
   };
 
-  // Number of steps left to run. Used to keep track of execution.
-  // If set to -1, runs until the execution ends.
-  const [stepsToRun, setStepsToRun] = React.useState(0);
-
-  // Signals that the simulation must pause.
-  const [mustPause, setMustPause] = React.useState(false);
-
-  // Tracks whether the worker is currently running code.
-  const [executing, setExecuting] = React.useState(false);
-
-  // Tracks whether the simulation is running in "run all" mode (run until finished).
-  const [runAll, setRunAll] = React.useState(false);
+  // Execution state machine — replaces the four individual useState variables
+  // (stepsToRun, mustPause, runAll, executing) that previously suffered from
+  // stale-closure races.  useReducer makes every transition atomic: the
+  // reducer sees the complete current state and emits a complete new state,
+  // so no individual setter can race another.  See executionReducer.js for
+  // the full action documentation.
+  const [execState, dispatch] = React.useReducer(
+    executionReducer,
+    initialExecState,
+  );
+  const { stepsToRun, mustPause, runAll, executing } = execState;
 
   const simulatorRunning = status == 'RUNNING';
 
@@ -291,9 +291,15 @@ const Simulator = ({worker, initialState, appInsights}) => {
     return parsingErrors.some((e) => !e.isWarning);
   };
 
-  worker.onmessage = (e) => {
+  // Worker message handler — stored in a ref so the addEventListener-based
+  // subscription (below) can register a single stable wrapper once, while
+  // the *real* handler body is reassigned on every render and therefore
+  // always reads the latest closures (execState, scheduleNextBatch, …).
+  // This is identical in structure to the existing keyboardHandlerRef pattern.
+  const workerHandlerRef = React.useRef(null);
+  workerHandlerRef.current = (e) => {
     const result = worker.parseResult(e.data);
-    
+
     // For syntax check responses, only update parsing errors to avoid unnecessary re-renders
     if (result.method === 'checksyntax') {
       setParsingErrors(result.parsingErrors);
@@ -307,13 +313,26 @@ const Simulator = ({worker, initialState, appInsights}) => {
 
     if (result.inputRequested) {
       applyResultState(result);
-      setExecuting(false);
+      dispatch({ type: 'INPUT_REQUESTED' });
       setInputRequest(result);
       return;
     }
-    
+
     updateState(result);
   };
+
+  // Register exactly one stable message listener for the lifetime of this
+  // component instead of the previous render-body `worker.onmessage = …`
+  // assignment, which was a side-effect during render — a React anti-pattern
+  // that could silently drop messages during Strict-Mode double-invocations
+  // and could not carry a cleanup.
+  React.useEffect(() => {
+    const handleMessage = (e) => workerHandlerRef.current(e);
+    worker.addEventListener('message', handleMessage);
+    return () => worker.removeEventListener('message', handleMessage);
+    // worker is a stable prop reference; include it so the linter is satisfied
+    // and so the subscription is re-created if a caller ever passes a new worker.
+  }, [worker]);
 
   const applyResultState = (result) => {
     setRegisters(result.registers);
@@ -351,16 +370,25 @@ const Simulator = ({worker, initialState, appInsights}) => {
       }
       alert(message);
       stopCode();
-      setExecuting(false);
-      // stopCode() queues state updates (setRunAll(false), setMustPause(true))
-      // and a worker.reset(), but those don't take effect within this closure.
-      // Return early to avoid falling through to the "schedule more steps"
-      // branch below, which would otherwise race worker.reset() with a new
-      // step() call against an already-reset (READY) CPU and surface a
-      // spurious "Cannot run in state READY" alert.
+      // stopCode() dispatches STOP (mustPause=true, runAll=false, stepsToRun=0),
+      // but since we are inside a worker-result handler (not a pending batch),
+      // hadPendingBatch is false and STOP leaves executing unchanged (still
+      // true).  Dispatch RESULT_RECEIVED with status='STOPPED' to atomically
+      // clear executing and reset all flags, preventing any follow-up batch
+      // from racing the worker.reset() already queued by stopCode().
+      dispatch({ type: 'RESULT_RECEIVED', status: 'STOPPED', encounteredBreak: false });
       return;
     }
 
+    // Dispatch the execution state transition atomically.  The reducer decides
+    // whether to stay in "executing" (more batches pending) or clear the flag.
+    dispatch({ type: 'RESULT_RECEIVED', status: result.status, encounteredBreak: result.encounteredBreak });
+
+    // Scheduling is a side-effect and cannot live inside the reducer.  We read
+    // the *pre-dispatch* execState here — which is correct, because the closure
+    // captured by workerHandlerRef.current reflects the last render before this
+    // message arrived (i.e., the state that drove the batch that just finished).
+    //
     // Note: we intentionally keep `executing === true` across inter-batch
     // delays when more steps are queued. Clearing `executing` between
     // batches would toggle the toolbar buttons (Run/Step/Stop becoming
@@ -369,19 +397,13 @@ const Simulator = ({worker, initialState, appInsights}) => {
     // should see the same "running" controls whether the worker is busy
     // stepping or we're simply waiting out the inter-batch delay.
     if (result.status !== 'RUNNING' || mustPause || result.encounteredBreak) {
-      setStepsToRun(0);
-      setMustPause(false);
-      setRunAll(false);
-      setExecuting(false);
+      // Execution halted; reducer already cleared all flags.  Nothing to schedule.
     } else if (stepsToRun > 0) {
       scheduleNextBatch(() => stepCode(stepsToRun));
     } else if (runAll) {
       scheduleNextBatch(() => stepCode(INTERNAL_STEPS_STRIDE));
-    } else {
-      // No further batches scheduled (e.g. a plain Single Step finishing):
-      // we're done executing for now.
-      setExecuting(false);
     }
+    // else: single step finished normally; reducer set executing=false — done.
   };
 
   // Pending timeout id for a delayed follow-up batch, so that stopping the
@@ -435,31 +457,27 @@ const Simulator = ({worker, initialState, appInsights}) => {
 
   // Business logic for click handlers.
   const runCode = () => {
-    setRunAll(true);
-    stepCode(INTERNAL_STEPS_STRIDE);
+    dispatch({ type: 'RUN_ALL_REQUESTED' });
+    worker.step(INTERNAL_STEPS_STRIDE);
   };
 
   const stepCode = (n) => {
     const toRun = Math.min(n, INTERNAL_STEPS_STRIDE);
-    setStepsToRun(n - toRun);
-    setExecuting(true);
+    dispatch({ type: 'STEP_REQUESTED', stepsRemaining: n - toRun });
     worker.step(toRun);
   };
 
   const stopCode = () => {
     // If a batch was sleeping between strides, cancel it. In that case no
     // worker result is in flight to flip `executing` back off via
-    // `updateState`, so clear it here too.
+    // `updateState`, so we pass hadPendingBatch=true and the reducer clears
+    // executing immediately.  When the worker is mid-step (hadPendingBatch
+    // false), the upcoming result will see mustPause=true and clear executing.
     const hadPendingBatch = nextBatchTimeout.current !== null;
     cancelPendingBatch();
-    setMustPause(true);
-    setRunAll(false);
-    setStepsToRun(0);
+    dispatch({ type: 'STOP', hadPendingBatch });
     setInputRequest(null);
-    if (hadPendingBatch) {
-      setExecuting(false);
-    }
-    worker.reset();  // Assuming simulator has a reset method
+    worker.reset();
   };
 
   const clearCode = () => {
@@ -468,9 +486,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
     setCode(".data\n\n.code\n  SYSCALL 0\n");
     isResetting.current = true;
     setInputRequest(null);
-    if (hadPendingBatch) {
-      setExecuting(false);
-    }
+    dispatch({ type: 'RESET', hadPendingBatch });
     worker.reset();
     // Clear accordion change markers
     setAccordionChanges({
@@ -500,9 +516,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
     setParsingErrors([]);
     isResetting.current = true;
     setInputRequest(null);
-    if (hadPendingBatch) {
-      setExecuting(false);
-    }
+    dispatch({ type: 'RESET', hadPendingBatch });
     worker.reset();
     // Run a fresh syntax check on the restored sample so any warnings in the
     // sample are surfaced immediately.
@@ -546,7 +560,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
 
   const submitInput = (input) => {
     setInputRequest(null);
-    setExecuting(true);
+    dispatch({ type: 'INPUT_SUBMITTED' });
     worker.provideInput(input);
   };
 
@@ -618,7 +632,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
           runCode();
         } else if (logicalState === 'EXECUTING') {
           appInsights.trackEvent({ name: 'pause', source: 'keyboard' });
-          setMustPause(true);
+          dispatch({ type: 'PAUSE_REQUESTED' });
         }
         break;
       case 'F9':
@@ -722,7 +736,7 @@ const Simulator = ({worker, initialState, appInsights}) => {
           onRunClick={clickRun}
           onPauseClick={() => {
             appInsights.trackEvent({ name: 'pause' });
-            setMustPause(true);
+            dispatch({ type: 'PAUSE_REQUESTED' });
           }}
           onStopClick={clickStop}
           status={status}

--- a/src/webapp/executionReducer.js
+++ b/src/webapp/executionReducer.js
@@ -1,0 +1,195 @@
+/**
+ * executionReducer.js — pure state machine for the EduMIPS64 execution flags.
+ *
+ * Why a reducer?
+ * --------------
+ * The original Simulator.js managed four related `useState` variables
+ * (`stepsToRun`, `mustPause`, `runAll`, `executing`) that must always
+ * move together. Because they were individual setters, every transition
+ * required multiple `set*` calls whose values were not visible to each
+ * other within the same event-handler invocation (React batching).
+ * Defensive workarounds (reads via refs, stale-closure guards) were
+ * scattered across the file.
+ *
+ * A single `useReducer` makes every legal transition explicit and atomic:
+ * the reducer receives the complete current state and produces a complete
+ * new state, so no individual setter can race another.
+ *
+ * No React imports — this module is pure JS and can be unit-tested without
+ * a browser or JSDOM.
+ */
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} ExecState
+ * @property {number}  stepsToRun  – steps still queued after the current
+ *   batch is dispatched to the worker; 0 = none pending.
+ * @property {boolean} mustPause   – pause flag: if true, the next
+ *   RESULT_RECEIVED transition clears all execution flags rather than
+ *   scheduling another batch.
+ * @property {boolean} runAll      – true while in "run until program ends"
+ *   mode; drives the open-ended scheduling loop in the component.
+ * @property {boolean} executing   – true while the worker is actively
+ *   computing steps *or* while a scheduled inter-batch delay is in flight.
+ *   Kept true across inter-batch delays so the toolbar buttons do not flash
+ *   between strides (user sees the same "running" UI the whole time).
+ */
+
+/** @type {ExecState} */
+export const initialExecState = {
+  stepsToRun: 0,
+  mustPause: false,
+  runAll: false,
+  executing: false,
+};
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Supported action types.  The component dispatches these; the reducer is the
+ * only place that decides what the new ExecState should be.
+ *
+ * STEP_REQUESTED      — user pressed Step (or a multi-step batch was scheduled).
+ *   payload: { stepsRemaining }  number of steps still queued after the
+ *   current batch is sent to the worker (i.e. n - stride, where stride =
+ *   Math.min(n, INTERNAL_STEPS_STRIDE)).  The actual worker.step(stride)
+ *   call is a side-effect kept in the component.
+ *
+ * RUN_ALL_REQUESTED   — user pressed Run All.
+ *   No payload.  Equivalent to the original setRunAll(true) + stepCode(...).
+ *   The component calls worker.step(INTERNAL_STEPS_STRIDE) as a side-effect.
+ *
+ * RESULT_RECEIVED     — a step result arrived from the worker.
+ *   payload: { status, encounteredBreak }
+ *   Based on the current state (mustPause, stepsToRun, runAll) and the
+ *   result the reducer decides whether to stay in "executing" (more batches
+ *   are expected) or to stop.  The component reads the *pre-dispatch* state
+ *   to decide which batch to schedule next (see Simulator.js).
+ *
+ * PAUSE_REQUESTED     — user pressed Pause (or keyboard F8 during run).
+ *   No payload.  Sets mustPause=true; the next RESULT_RECEIVED will stop.
+ *
+ * STOP                — user pressed Stop, or a runtime error was detected.
+ *   payload: { hadPendingBatch } boolean — true when cancelPendingBatch()
+ *   found a live timeout.  In that case no worker result is in flight, so
+ *   we must clear executing immediately.  When the worker is mid-step,
+ *   executing stays true until the response arrives and sees mustPause=true.
+ *
+ * RESET               — clearCode() / restoreDefaultSample() called.
+ *   payload: { hadPendingBatch }  Same semantics as STOP for executing.
+ *   Does NOT set mustPause; the worker.reset() response will arrive with
+ *   status='READY' and the RESULT_RECEIVED first-branch will clear all flags.
+ *
+ * INPUT_REQUESTED     — worker signalled it needs stdin input.
+ *   No payload.  Pauses execution until the user submits.
+ *
+ * INPUT_SUBMITTED     — user submitted input via the InputDialog.
+ *   No payload.  Resumes execution (worker.provideInput is the side-effect).
+ */
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {ExecState} state
+ * @param {{ type: string, [key: string]: * }} action
+ * @returns {ExecState}
+ */
+export function executionReducer(state, action) {
+  switch (action.type) {
+    case 'STEP_REQUESTED':
+      // The component has already called worker.step(stride).  Record how
+      // many steps remain after this batch and mark execution as in-progress.
+      return {
+        ...state,
+        stepsToRun: action.stepsRemaining,
+        executing: true,
+      };
+
+    case 'RUN_ALL_REQUESTED':
+      // Open-ended run: subsequent batches are driven by the runAll flag, not
+      // by a decreasing stepsToRun counter.
+      return {
+        ...state,
+        runAll: true,
+        stepsToRun: 0,
+        executing: true,
+      };
+
+    case 'RESULT_RECEIVED': {
+      const { status, encounteredBreak } = action;
+
+      // Invariant: stop execution when the program has ended, the user asked
+      // to pause, or a breakpoint was hit.  Clear all flags atomically so no
+      // subsequent RESULT_RECEIVED can re-schedule work.
+      if (status !== 'RUNNING' || state.mustPause || encounteredBreak) {
+        return {
+          stepsToRun: 0,
+          mustPause: false,
+          runAll: false,
+          executing: false,
+        };
+      }
+
+      // More steps are queued (stepsToRun > 0) or we're in run-all mode:
+      // keep executing=true so the toolbar stays in "running" state across
+      // the inter-batch delay.  The component will call scheduleNextBatch
+      // based on the pre-dispatch state it read from the workerHandlerRef
+      // closure (see Simulator.js for the full scheduling comment).
+      if (state.stepsToRun > 0 || state.runAll) {
+        return state;
+      }
+
+      // A plain single-step (or the final batch of a multi-step) completed
+      // normally.  No further batches are queued.
+      return { ...state, executing: false };
+    }
+
+    case 'PAUSE_REQUESTED':
+      // Record the pause intent; the next RESULT_RECEIVED will stop the run.
+      return { ...state, mustPause: true };
+
+    case 'STOP':
+      // stopCode(): cancelled pending batch + will call worker.reset().
+      // If hadPendingBatch is true, no worker response is in flight so we
+      // clear executing right now.  Otherwise the worker is mid-step; its
+      // response will arrive with mustPause=true visible and will clear
+      // executing via the RESULT_RECEIVED first-branch above.
+      return {
+        stepsToRun: 0,
+        mustPause: true,
+        runAll: false,
+        executing: action.hadPendingBatch ? false : state.executing,
+      };
+
+    case 'RESET':
+      // clearCode() / restoreDefaultSample(): same hadPendingBatch logic as
+      // STOP for executing.  mustPause is NOT set here because worker.reset()
+      // will send back a response with status='READY'; the RESULT_RECEIVED
+      // first-branch (status !== 'RUNNING') will then clear all remaining flags.
+      return {
+        stepsToRun: 0,
+        mustPause: false,
+        runAll: false,
+        executing: action.hadPendingBatch ? false : state.executing,
+      };
+
+    case 'INPUT_REQUESTED':
+      // Worker needs stdin: pause execution while the InputDialog is open.
+      // The worker will resume when worker.provideInput() is called.
+      return { ...state, executing: false };
+
+    case 'INPUT_SUBMITTED':
+      // User provided the required input; execution resumes.
+      return { ...state, executing: true };
+
+    default:
+      return state;
+  }
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Only pick up unit tests in the dedicated unit-test directory.
+    // The Playwright specs in src/test/webapp are excluded intentionally:
+    // they use @playwright/test globals and expect a real browser.
+    include: ['src/test/webapp-unit/**/*.test.js'],
+  },
+});


### PR DESCRIPTION
## Problem

`Simulator.js` had two related architectural issues:

**1. Side-effect during render (`worker.onmessage = …`).**
Assigning `worker.onmessage` directly in the component render body is a React anti-pattern. React's Strict Mode double-invokes renders, which can silently discard a message. There is also no cleanup path — the assignment is permanent for the component's lifetime and cannot be torn down if the component unmounts.

**2. Stale-closure races across four `useState` variables.**
The execution state machine was spread across four individual state variables (`stepsToRun`, `mustPause`, `runAll`, `executing`). Because React batches state updates, a handler captured at render time could read superseded values of `mustPause` or `stepsToRun`, creating scheduling race conditions. The original code worked around this defensively throughout the file.

## Design

### `src/webapp/executionReducer.js` (new)
A pure reducer module (no React imports) that owns the four execution flags as a single, atomically-transitioned state object:
```
{ stepsToRun, mustPause, runAll, executing }
```
Every legal transition is an explicit named action: `STEP_REQUESTED`, `RUN_ALL_REQUESTED`, `RESULT_RECEIVED`, `PAUSE_REQUESTED`, `STOP`, `RESET`, `INPUT_REQUESTED`, `INPUT_SUBMITTED`. The semantics of the original booleans are preserved exactly — the reducer is a direct translation of the state-machine logic previously scattered across `updateState`, `stepCode`, `runCode`, and `stopCode`.

### `src/webapp/components/Simulator.js` (refactored)
- Four `useState` calls replaced by `React.useReducer(executionReducer, initialExecState)`. Destructuring preserves all downstream references to `executing`, `mustPause`, etc. unchanged.
- The render-body `worker.onmessage = …` assignment replaced by a `React.useEffect` that calls `worker.addEventListener('message', handler)` with a `removeEventListener` cleanup. The actual handler lives in `workerHandlerRef` (reassigned every render — identical pattern to the existing `keyboardHandlerRef`), so the stable wrapper registered by the effect always delegates to the freshest closures, eliminating the stale-closure race without any additional defensive ref reads.

High-risk areas preserved unchanged: delayed-batch scheduling (`executionDelayRef`, `nextBatchTimeout`, `scheduleNextBatch`, `cancelPendingBatch`), `mustPause` semantics, `encounteredBreak` handling, input-request flow, `stopCode`/`clearCode`/`restoreDefaultSample` interplay including `hadPendingBatch` logic, the early-return after runtime-error alerts, and the `checksyntax` short-circuit.

### Unit tests (`src/test/webapp-unit/`)
Added Vitest (`npm install --save-dev vitest`, `"test:unit": "vitest run"` script) with a dedicated `vitest.config.js` that restricts test discovery to `src/test/webapp-unit/**` so it never picks up the Playwright specs.

32 unit tests in two files:
- `executionReducer.test.js` — covers every action (single step, multi-step batching across several RESULT_RECEIVED cycles, run-all, pause during run, stop with/without pending batch, program-ended result, encounteredBreak, input request round-trip, unknown action defensive case)
- `simulatorState.test.js` — covers all five logical states returned by `deriveLogicalState`

### CI (`.github/workflows/ci.yml`)
A "Run JS unit tests" step (`npm run test:unit`) added to `test-web-coverage` immediately after "Install JS dependencies".

## Verification

- `npm run test:unit`: **32 passed** (2 test files)
- `npm run build-dbg`: webpack compiled successfully
- Full Playwright e2e suite: **87 passed, 1 skipped** (pre-existing skip, unrelated to this PR)
- `npx eslint src/webapp/executionReducer.js src/webapp/components/Simulator.js`: no new errors relative to master (pre-existing prettier/formatting noise unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)