### PR TITLE
Fix embedded web version: quote the git-describe tag glob

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,12 @@ const copyPlugin = new CopyPlugin({
   ],
 });
 const grPlugin = new GitRevisionPlugin({
-  versionCommand: 'describe --tags --match v* --always --dirty',
+  // The plugin runs this through a shell (child_process.execSync with a
+  // joined string), so the glob MUST be quoted: an unquoted v* is expanded
+  // by the shell against the repo root, and since vitest.config.js exists
+  // it became `--match vitest.config.js` — no tag matched and the version
+  // silently degraded to a bare commit sha.
+  versionCommand: "describe --tags --match 'v*' --always --dirty",
 });
 const versionsPlugin = new webpack.DefinePlugin({
   VERSION: JSON.stringify(grPlugin.version().replace(/^v/, '')),


### PR DESCRIPTION
## Symptom

Since #1910 merged, production web bundles embed a **bare short sha** (e.g. `2bec1525`) instead of the full `1.4.0-179-g2bec1525` version. Effects: About dialog shows just a sha, App Insights version tagging degraded, and the promote workflow's new CDN verification step (#1909) failed its 12-minute timeout tonight because it greps for the full build string (the promotion itself was fine — production serves the right bytes, verified byte-identical to the candidate).

## Root cause

`git-revision-webpack-plugin` executes its `versionCommand` **through a shell** (`child_process.execSync` on a joined string), so the unquoted glob in `describe --tags --match v* --always --dirty` gets shell-expanded against the repo root. That was harmless while no root file started with `v` — but #1910 added `vitest.config.js`, so the command became `--match vitest.config.js`, no tag matched, and `--always` fell back to the bare sha. (The same mechanism caused the `a420bd5b-dirty` CI test failure investigated during #1910.)

## Fix

Quote the glob: `--match 'v*'`. Verified locally: production bundle embeds `1.4.0-179-g2bec1525[-dirty]` again.

## Note

The currently-promoted production build predates this fix and shows the bare sha in About — cosmetic only; the next promotion picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)