### PR TITLE
Web UI: enable React.StrictMode in development

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -182,15 +182,45 @@ The `webapp` Gradle task automates the build process for the web UI. It:
 
 Custom NPM scripts:
 
-- `build-dbg`: runs `webpack -d` (compile with debugging symbols)
-- `build`: runs `webpack -p` (compile without debugging symbols, minified, etc)
+- `build-dbg`: development webpack build (inline source maps, React dev mode)
+- `build`: production webpack build (minified, production React runtime)
 - `start`: starts the webpack-dev-server with live reloading
+- `test`: runs the Playwright end-to-end tests (expects the app to be
+  served at `http://localhost:8080`, or set `PLAYWRIGHT_TARGET_URL`)
+- `test:unit`: runs the Vitest unit tests (fast, no browser; covers the
+  pure modules under `src/webapp` from `src/test/webapp-unit/`)
 
 Both `build` and `build-dbg` produce a `ui.js` file in the `out/web` directory.
 
-The code was tested with Node.JS 16. The CI environment uses this version.
+The required Node.JS version is pinned in `.nvmrc` (currently Node 24); CI
+installs dependencies with `npm ci`, so `package-lock.json` must stay
+canonical for that npm major version.
 
-There are Playwright tests for the web UI, which can be run with `npm test`.
+##### Web UI architecture
+
+- `index.js` boots App Insights, wraps the Web Worker (`worker.js`, the
+  simulator core compiled from Java) with helper methods, and mounts React
+  immediately inside `React.StrictMode` and an `AppErrorBoundary`.
+- `components/AppLoader.js` shows a loading indicator while the worker
+  initialises, and a friendly error screen (30 s watchdog) if `worker.js`
+  fails to load — the app can no longer silently render a blank page.
+- `components/Simulator.js` is the orchestrator. The heavy lifting lives in
+  hooks under `src/webapp/hooks/`:
+  - `useSimulatorData` — registers/memory/stats/pipeline/… state. Updates
+    are *reference-preserving* (deep-equal data keeps the previous object)
+    so the `React.memo`-wrapped display panels skip re-rendering when their
+    data did not change.
+  - `useExecutionController` — owns `executionReducer.js` (a pure, fully
+    unit-tested state machine for run/step/pause/stop and batch
+    scheduling) and the worker `message` subscription.
+  - `useKeyboardShortcuts` — the global F2/F8/F9/F10/Esc bindings.
+- Runtime errors surface in `RuntimeErrorDialog` (never `window.alert`).
+- `React.StrictMode` is enabled in development builds: render functions and
+  effects are intentionally double-invoked to flush out unsafe side
+  effects. New code must keep side effects out of render bodies and class
+  constructors, and every effect/listener needs a working cleanup — the
+  Playwright suite runs against a development build, so StrictMode
+  violations typically show up as e2e failures.
 
 #### Build environment indicator
 

--- a/src/webapp/components/AppLoader.js
+++ b/src/webapp/components/AppLoader.js
@@ -22,17 +22,18 @@ import errorImage from '../static/error-hires.png';
  *                expired; an error panel is shown with a Reload button.
  *
  * Design choices:
- *   - The 'message' and 'error' listeners are attached synchronously in the
- *     constructor so they are guaranteed to be in place before
- *     componentDidMount calls worker.reset().  A useEffect-based approach
- *     would be equivalent for mount (effects also run after commit), but a
- *     class constructor makes the ordering explicit and avoids any ambiguity
- *     with React's concurrent scheduler.
- *   - worker.reset() is called from componentDidMount (NOT from index.js).
- *     React's commit phase runs the constructor → render → componentDidMount
- *     sequence atomically before yielding to the browser event loop, so the
- *     listener is always in place before reset() triggers the first worker
- *     message.  index.js must NOT call worker.reset() itself.
+ *   - The 'message' and 'error' listeners are attached in componentDidMount,
+ *     immediately before worker.reset() is called in the same method. The
+ *     worker only speaks when spoken to, so attaching and kicking in the same
+ *     synchronous block guarantees the init message is never missed. Doing
+ *     this in the constructor would be a side effect during render, which
+ *     React.StrictMode intentionally double-invokes — leaking a listener and
+ *     a watchdog timer per extra invocation.
+ *   - worker.reset() is called from componentDidMount (NOT from index.js);
+ *     index.js must NOT call worker.reset() itself. Under StrictMode's
+ *     dev-only mount→unmount→remount cycle reset() runs twice; the second
+ *     init message is consumed by the Simulator's own listener as a regular
+ *     READY result, which is harmless.
  *
  * Props:
  *   worker      – augmented Worker instance (parseResult / step / … already
@@ -48,18 +49,6 @@ class AppLoader extends React.Component {
     // Bind handlers so they can be removed from the worker later.
     this._onMessage = this._onMessage.bind(this);
     this._onError = this._onError.bind(this);
-
-    // Attach listeners NOW (synchronously, before reset() is called by the
-    // parent).  This ensures the first message is never missed.
-    this.props.worker.addEventListener('message', this._onMessage);
-    this.props.worker.addEventListener('error', this._onError);
-
-    // Arm a 30-second watchdog.  If neither a message nor an error event
-    // arrives within this window we surface an error so the user is not left
-    // staring at a blank spinner forever.
-    this._timeout = setTimeout(() => {
-      this._fail('The simulator core did not respond within 30 seconds. The worker.js file may be missing or failed to start.');
-    }, 30000);
   }
 
   _onMessage(evt) {
@@ -70,19 +59,26 @@ class AppLoader extends React.Component {
       const initialState = this.props.worker.parseResult(evt.data);
       this.setState({ phase: 'ready', initialState });
     } catch (err) {
-      this._fail(`Failed to parse the worker initialisation message: ${err.message}`);
+      this._fail(
+        `Failed to parse the worker initialisation message: ${err.message}`,
+      );
     }
   }
 
   _onError(evt) {
     this._cleanup();
-    const msg = (evt && evt.message) ? evt.message : 'The worker encountered an error during startup.';
+    const msg =
+      evt && evt.message
+        ? evt.message
+        : 'The worker encountered an error during startup.';
     this._fail(msg);
   }
 
   _fail(errorMessage) {
     try {
-      this.props.appInsights?.trackException?.({ exception: new Error(errorMessage) });
+      this.props.appInsights?.trackException?.({
+        exception: new Error(errorMessage),
+      });
     } catch (_) {
       // intentionally swallowed
     }
@@ -99,9 +95,23 @@ class AppLoader extends React.Component {
   }
 
   componentDidMount() {
-    // Kick the worker here — after the constructor has attached its listeners —
-    // to guarantee the init message is never missed regardless of React's
-    // scheduling behaviour.
+    // Attach listeners and kick the worker in the same synchronous block:
+    // the worker only emits messages in response to requests, so nothing can
+    // arrive between addEventListener and reset(). Listeners live in
+    // componentDidMount (not the constructor) so StrictMode's double-invoked
+    // constructor cannot leak them; componentWillUnmount cleans them up.
+    this.props.worker.addEventListener('message', this._onMessage);
+    this.props.worker.addEventListener('error', this._onError);
+
+    // Arm a 30-second watchdog. If neither a message nor an error event
+    // arrives within this window we surface an error so the user is not left
+    // staring at a blank spinner forever.
+    this._timeout = setTimeout(() => {
+      this._fail(
+        'The simulator core did not respond within 30 seconds. The worker.js file may be missing or failed to start.',
+      );
+    }, 30000);
+
     this.props.worker.reset();
   }
 
@@ -161,7 +171,10 @@ class AppLoader extends React.Component {
             <Typography variant="h6" color="error">
               Failed to load the EduMIPS64 simulator core
             </Typography>
-            <Typography variant="body2" sx={{ maxWidth: 500, textAlign: 'center' }}>
+            <Typography
+              variant="body2"
+              sx={{ maxWidth: 500, textAlign: 'center' }}
+            >
               {errorMessage}
             </Typography>
             <Button

--- a/src/webapp/components/Code.js
+++ b/src/webapp/components/Code.js
@@ -303,6 +303,19 @@ const Code = (props) => {
     };
   }, [props.parsedInstructions, stageMap, monaco]);
 
+  // react-monaco-editor disposes the *editor* on unmount but not its
+  // *model*. Monaco models are global, so every unmount leaks one — and
+  // under React.StrictMode's dev-only double-mount the leaked first model
+  // makes `monaco.editor.getModels()[0]` point at a stale orphan (which is
+  // exactly what the Playwright helpers read). Disposing the model here
+  // keeps the global model list in sync with the mounted editor.
+  const editorWillUnmount = (editor) => {
+    const model = editor.getModel();
+    if (model) {
+      model.dispose();
+    }
+  };
+
   const editorDidMount = (editor, monaco) => {
     // Expose monaco and editor to window for testing purposes
     window.monaco = monaco;
@@ -420,6 +433,7 @@ const Code = (props) => {
         onChange={props.onChangeValue}
         theme={editorTheme}
         editorDidMount={editorDidMount}
+        editorWillUnmount={editorWillUnmount}
       />
     </div>
   );

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -6,8 +6,7 @@ import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import AppErrorBoundary from './components/AppErrorBoundary';
 import AppLoader from './components/AppLoader';
 
-import './css/main.css'
-
+import './css/main.css';
 
 // Set version from the webpack variables. Uses globals defined by webpack.
 // VERSION is git-describe (e.g. "1.4.0-74-ge1b45a15"), matching desktop identity.
@@ -17,15 +16,16 @@ const version = VERSION;
 // Initialize AppInsights.
 const appInsights = new ApplicationInsights({
   config: {
-    connectionString: 'InstrumentationKey=ae180a87-f990-410c-a51c-8077c240e265;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/',
+    connectionString:
+      'InstrumentationKey=ae180a87-f990-410c-a51c-8077c240e265;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/',
   },
 });
 appInsights.loadAppInsights();
 appInsights.context.application.ver = version;
 appInsights.context.application.build = version;
 const telemetryInitializer = (envelope) => {
-  envelope.tags['ai.cloud.role'] = process.env.NODE_ENV,
-  envelope.tags['ai.cloud.roleInstance'] = version;
+  ((envelope.tags['ai.cloud.role'] = process.env.NODE_ENV),
+    (envelope.tags['ai.cloud.roleInstance'] = version));
 };
 appInsights.addTelemetryInitializer(telemetryInitializer);
 appInsights.trackPageView();
@@ -36,15 +36,15 @@ appInsights.trackPageView();
 let worker = new Worker('worker.js');
 worker.reset = () => {
   worker.postMessage({ method: 'reset' });
-  appInsights.trackEvent({name: "reset"});
+  appInsights.trackEvent({ name: 'reset' });
 };
 worker.step = (n) => {
   worker.postMessage({ method: 'step', steps: n });
-  appInsights.trackEvent({name: 'step', properties: {steps: n}});
+  appInsights.trackEvent({ name: 'step', properties: { steps: n } });
 };
 worker.load = (code) => {
   worker.postMessage({ method: 'load', code });
-  appInsights.trackEvent({name: "load"});
+  appInsights.trackEvent({ name: 'load' });
 };
 
 worker.setCacheConfig = (config) => {
@@ -62,7 +62,7 @@ worker.setDelaySlot = (enabled) => {
 worker.checkSyntax = (code) => {
   worker.postMessage({ method: 'checksyntax', code });
 
-  appInsights.trackEvent({name: "checkSyntax"});
+  appInsights.trackEvent({ name: 'checkSyntax' });
 };
 worker.provideInput = (input) => {
   worker.postMessage({ method: 'provideInput', input });
@@ -76,14 +76,21 @@ worker.parseResult = (result) => {
 worker.version = version;
 
 // Mount React immediately so the user sees a loading indicator rather than
-// a blank page.  AppLoader registers its 'message'/'error' listeners in its
-// constructor and calls worker.reset() in componentDidMount, ensuring the
-// listener is always in place before the first worker message arrives.
+// a blank page.  AppLoader attaches its 'message'/'error' listeners and
+// calls worker.reset() in the same componentDidMount block, so the init
+// message can never be missed.
+//
+// StrictMode is a development-only canary: it double-invokes render
+// functions, constructors and effect setup/cleanup to surface unsafe side
+// effects (like the render-body worker.onmessage assignment fixed in
+// #1910). It renders nothing and has zero effect in production builds.
 const container = document.getElementById('simulator');
 const root = createRoot(container);
 
 root.render(
-  <AppErrorBoundary appInsights={appInsights}>
-    <AppLoader worker={worker} appInsights={appInsights} />
-  </AppErrorBoundary>
+  <React.StrictMode>
+    <AppErrorBoundary appInsights={appInsights}>
+      <AppLoader worker={worker} appInsights={appInsights} />
+    </AppErrorBoundary>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
Backlog item from the code review, unblocked by #1910/#1911/#1916. StrictMode double-invokes renders, constructors and effect cycles in development builds so unsafe side effects fail fast — our e2e suite runs against dev builds, so violations surface as test failures from now on.

Enabling it caught two real issues, both fixed here:

1. **AppLoader constructor side effects**: worker listeners + the 30s watchdog were attached in the constructor. Moved to `componentDidMount`, attached in the same synchronous block as `worker.reset()` (the worker only speaks when spoken to, so the init message cannot be missed). The dev-only double-mount runs `reset()` twice; the straggler READY response is consumed by the Simulator as a regular result — harmless.
2. **Monaco model leak**: `react-monaco-editor` disposes the editor on unmount but not its global *model*; the double-mount left an orphaned stale model as `getModels()[0]` — exactly what the Playwright helpers read. `Code.js` now disposes the model in `editorWillUnmount`. (This was a real leak in every unmount, not just a StrictMode artifact.)

Also refreshes the Web UI section of `docs/developer-guide.md`: post-split architecture (hooks, execution reducer, error screens), `test:unit`, the `.nvmrc`/`npm ci` policy, and what StrictMode expects of new code. Production builds are completely unaffected (StrictMode compiles away).

## Verification
- 32 unit tests green.
- Full Playwright suite against a **StrictMode dev build**: **88 passed, 1 skipped**.
- Headless probe: exactly one Monaco model before/after Program → New (was two).
- ESLint: fewer problems than the master baseline for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)