### PR TITLE
Web UI TypeScript, phase 2: hooks, typed useSetting, entry components

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -199,19 +199,28 @@ TypeScript is being adopted **incrementally**. The build toolchain (Babel +
 webpack) already handles `.ts`/`.tsx` files transparently, so converting a
 module does not break JS importers (all imports are extensionless).
 
-Current state (phase 1):
+Current state (phase 2):
 - **New webapp code should be `.ts`/`.tsx`** — the toolchain and `tsconfig.json`
   are fully wired.
-- **Existing `.js` files are not type-checked** (`checkJs: false` in
+- **Remaining `.js` files are not type-checked** (`checkJs: false` in
   `tsconfig.json`); they continue to work without modification.
-- The pure, high-leverage modules have been converted first:
-  `executionReducer.ts`, `simulatorState.ts`, `buildInfo.ts`,
-  `versionHistory.ts`, `settings/SettingKey.ts`, `settings/schema.ts`,
-  `hooks/useLocalStorage.ts`, `settings/useSetting.ts`.
-  Worker-boundary types live in `simulator/protocol.ts`.
+- Converted so far:
+  - Pure logic: `executionReducer.ts`, `simulatorState.ts`, `buildInfo.ts`,
+    `versionHistory.ts`, `settings/SettingKey.ts`, `settings/schema.ts`,
+    `hooks/useLocalStorage.ts`, `settings/useSetting.ts`.
+    Worker-boundary types live in `simulator/protocol.ts`.
+  - Hooks (phase 2): `hooks/useSimulatorData.ts`, `hooks/useExecutionController.ts`,
+    `hooks/useKeyboardShortcuts.ts`.
+  - Entry components (phase 2): `components/AppErrorBoundary.tsx`,
+    `components/AppLoader.tsx`, `components/RuntimeErrorDialog.tsx`.
+- `settings/schema.ts` exports a `SettingValueMap` interface that maps every
+  `SettingKey` string value to its concrete TypeScript type; `useSetting<K>`
+  uses this to give call sites a precisely-typed `[value, setValue, reset]`
+  tuple with no casts.
 - Unit tests for the converted modules are `.test.ts`; Vitest handles TS
   natively (no extra configuration needed).
-- Phase 2 will convert the hooks; phase 3 the components.
+- Phase 3 will convert `Simulator.js`, `Code.js`, `index.js`, and the display
+  components.
 
 `npm run typecheck` is enforced in CI (`test-web-coverage` job) and must
 stay clean for PRs to merge.
@@ -227,20 +236,20 @@ canonical for that npm major version.
 - `index.js` boots App Insights, wraps the Web Worker (`worker.js`, the
   simulator core compiled from Java) with helper methods, and mounts React
   immediately inside `React.StrictMode` and an `AppErrorBoundary`.
-- `components/AppLoader.js` shows a loading indicator while the worker
+- `components/AppLoader.tsx` shows a loading indicator while the worker
   initialises, and a friendly error screen (30 s watchdog) if `worker.js`
   fails to load — the app can no longer silently render a blank page.
 - `components/Simulator.js` is the orchestrator. The heavy lifting lives in
-  hooks under `src/webapp/hooks/`:
-  - `useSimulatorData` — registers/memory/stats/pipeline/… state. Updates
+  typed hooks under `src/webapp/hooks/`:
+  - `useSimulatorData.ts` — registers/memory/stats/pipeline/… state. Updates
     are *reference-preserving* (deep-equal data keeps the previous object)
     so the `React.memo`-wrapped display panels skip re-rendering when their
     data did not change.
-  - `useExecutionController` — owns `executionReducer.ts` (a pure, fully
+  - `useExecutionController.ts` — owns `executionReducer.ts` (a pure, fully
     unit-tested state machine for run/step/pause/stop and batch
     scheduling) and the worker `message` subscription.
-  - `useKeyboardShortcuts` — the global F2/F8/F9/F10/Esc bindings.
-- Runtime errors surface in `RuntimeErrorDialog` (never `window.alert`).
+  - `useKeyboardShortcuts.ts` — the global F2/F8/F9/F10/Esc bindings.
+- Runtime errors surface in `components/RuntimeErrorDialog.tsx` (never `window.alert`).
 - `React.StrictMode` is enabled in development builds: render functions and
   effects are intentionally double-invoked to flush out unsafe side
   effects. New code must keep side effects out of render bodies and class

--- a/src/webapp/components/AppErrorBoundary.tsx
+++ b/src/webapp/components/AppErrorBoundary.tsx
@@ -9,9 +9,32 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
+import type { ITelemetryClient } from '../telemetry';
+
 // The cracked-CPU artwork that the Swing UI's ErrorDialog has shown for
 // years — reused here so the web error screen keeps the same personality.
 import errorImage from '../static/error-hires.png';
+
+// ---------------------------------------------------------------------------
+// Props and state types
+// ---------------------------------------------------------------------------
+
+interface AppErrorBoundaryProps {
+  /**
+   * Optional telemetry client. When provided, render errors are tracked via
+   * `trackException`. A missing or partially-initialised instance is handled
+   * safely (the try/catch in componentDidCatch suppresses any telemetry errors).
+   */
+  appInsights?: ITelemetryClient;
+  /** The wrapped component tree. */
+  children: React.ReactNode;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
 
 /**
  * Top-level error boundary that catches render/lifecycle errors anywhere in
@@ -19,41 +42,42 @@ import errorImage from '../static/error-hires.png';
  *
  * Error boundaries MUST be class components – React does not support the
  * componentDidCatch lifecycle method in function components.
- *
- * Props:
- *   appInsights  – (optional) ApplicationInsights instance. When provided,
- *                  exceptions are tracked via trackException. A missing or
- *                  partially-initialised instance is handled safely.
- *   children     – the wrapped component tree.
  */
-class AppErrorBoundary extends React.Component {
-  constructor(props) {
+class AppErrorBoundary extends React.Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  constructor(props: AppErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: null, errorInfo: null };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError(error: Error): Partial<AppErrorBoundaryState> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error, errorInfo) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     this.setState({ errorInfo });
     // Guard so a missing / partially-constructed appInsights never throws.
     try {
       this.props.appInsights?.trackException?.({ exception: error });
-    } catch (_) {
+    } catch {
       // intentionally swallowed
     }
   }
 
-  render() {
+  render(): React.ReactNode {
     if (!this.state.hasError) {
       return this.props.children;
     }
 
     const { error, errorInfo } = this.state;
     const message = error ? error.message : 'An unknown error occurred.';
-    const stack = errorInfo ? errorInfo.componentStack : (error && error.stack ? error.stack : '');
+    const stack = errorInfo
+      ? errorInfo.componentStack
+      : error && error.stack
+        ? error.stack
+        : '';
 
     return (
       <Box
@@ -89,7 +113,11 @@ class AppErrorBoundary extends React.Component {
               <Typography
                 variant="caption"
                 component="pre"
-                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', fontSize: '0.75rem' }}
+                sx={{
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                  fontSize: '0.75rem',
+                }}
               >
                 {stack}
               </Typography>

--- a/src/webapp/components/AppLoader.tsx
+++ b/src/webapp/components/AppLoader.tsx
@@ -6,20 +6,55 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 
+// Simulator is still a .js component (converted in phase 3); TypeScript
+// treats the import as the inferred JS export shape (checkJs: false).
 import Simulator from './Simulator';
+
+import type { SimulatorResult, SimulatorWorker } from '../simulator/protocol';
+import type { ITelemetryClient } from '../telemetry';
 
 // The cracked-CPU artwork that the Swing UI's ErrorDialog has shown for
 // years — reused here so the web error screen keeps the same personality.
 import errorImage from '../static/error-hires.png';
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of the three loading phases.
+ *   loading  – waiting for the first worker message.
+ *   ready    – Simulator can render with the parsed initial state.
+ *   error    – the worker errored or the 30-second watchdog expired.
+ */
+type LoaderPhase = 'loading' | 'ready' | 'error';
+
+interface AppLoaderProps {
+  /**
+   * Augmented Worker instance (parseResult / step / reset / … methods are
+   * already monkey-patched by index.js before AppLoader mounts).
+   */
+  worker: SimulatorWorker;
+  /** Optional telemetry client; load failures are reported via trackException. */
+  appInsights?: ITelemetryClient;
+}
+
+interface AppLoaderState {
+  phase: LoaderPhase;
+  /** Set when phase === 'ready'; the parsed initial CPU state from the worker. */
+  initialState: SimulatorResult | null;
+  /** Set when phase === 'error'; human-readable description of the failure. */
+  errorMessage: string | null;
+}
+
 /**
  * AppLoader mounts immediately and handles the worker initialisation
- * handshake.  Three states:
+ * handshake.  Three phases:
  *
- *   loading    – spinner is shown while waiting for the first worker message.
- *   ready      – Simulator is rendered with the parsed initial state.
- *   error      – the worker fired an 'error' event OR the 30-second timeout
- *                expired; an error panel is shown with a Reload button.
+ *   loading  – spinner is shown while waiting for the first worker message.
+ *   ready    – Simulator is rendered with the parsed initial state.
+ *   error    – the worker fired an 'error' event OR the 30-second timeout
+ *              expired; an error panel is shown with a Reload button.
  *
  * Design choices:
  *   - The 'message' and 'error' listeners are attached in componentDidMount,
@@ -34,38 +69,36 @@ import errorImage from '../static/error-hires.png';
  *     dev-only mount→unmount→remount cycle reset() runs twice; the second
  *     init message is consumed by the Simulator's own listener as a regular
  *     READY result, which is harmless.
- *
- * Props:
- *   worker      – augmented Worker instance (parseResult / step / … already
- *                 monkey-patched by index.js).
- *   appInsights – (optional) ApplicationInsights instance.
  */
-class AppLoader extends React.Component {
-  constructor(props) {
+class AppLoader extends React.Component<AppLoaderProps, AppLoaderState> {
+  private _timeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(props: AppLoaderProps) {
     super(props);
     this.state = { phase: 'loading', initialState: null, errorMessage: null };
-    this._timeout = null;
 
     // Bind handlers so they can be removed from the worker later.
     this._onMessage = this._onMessage.bind(this);
     this._onError = this._onError.bind(this);
   }
 
-  _onMessage(evt) {
+  private _onMessage(evt: MessageEvent): void {
     // Only handle the very first message; Simulator.js registers its own
     // listener for all subsequent messages.
     this._cleanup();
     try {
-      const initialState = this.props.worker.parseResult(evt.data);
+      const initialState = this.props.worker.parseResult(
+        evt.data as Record<string, unknown>,
+      );
       this.setState({ phase: 'ready', initialState });
     } catch (err) {
       this._fail(
-        `Failed to parse the worker initialisation message: ${err.message}`,
+        `Failed to parse the worker initialisation message: ${(err as Error).message}`,
       );
     }
   }
 
-  _onError(evt) {
+  private _onError(evt: ErrorEvent): void {
     this._cleanup();
     const msg =
       evt && evt.message
@@ -74,18 +107,18 @@ class AppLoader extends React.Component {
     this._fail(msg);
   }
 
-  _fail(errorMessage) {
+  private _fail(errorMessage: string): void {
     try {
       this.props.appInsights?.trackException?.({
         exception: new Error(errorMessage),
       });
-    } catch (_) {
+    } catch {
       // intentionally swallowed
     }
     this.setState({ phase: 'error', errorMessage });
   }
 
-  _cleanup() {
+  private _cleanup(): void {
     if (this._timeout !== null) {
       clearTimeout(this._timeout);
       this._timeout = null;
@@ -94,7 +127,7 @@ class AppLoader extends React.Component {
     this.props.worker.removeEventListener('error', this._onError);
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     // Attach listeners and kick the worker in the same synchronous block:
     // the worker only emits messages in response to requests, so nothing can
     // arrive between addEventListener and reset(). Listeners live in
@@ -115,11 +148,11 @@ class AppLoader extends React.Component {
     this.props.worker.reset();
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this._cleanup();
   }
 
-  render() {
+  render(): React.ReactNode {
     const { phase, initialState, errorMessage } = this.state;
     const { worker, appInsights } = this.props;
 

--- a/src/webapp/components/RuntimeErrorDialog.tsx
+++ b/src/webapp/components/RuntimeErrorDialog.tsx
@@ -12,6 +12,19 @@ import Typography from '@mui/material/Typography';
 // left of the message like a classic JOptionPane error icon.
 import errorImage from '../static/error-hires.png';
 
+// ---------------------------------------------------------------------------
+// Props type
+// ---------------------------------------------------------------------------
+
+interface RuntimeErrorDialogProps {
+  /** Controls dialog visibility. */
+  open: boolean;
+  /** Human-readable error message to display (may contain newlines). */
+  message: string;
+  /** Callback invoked when the user clicks OK or dismisses the dialog. */
+  onClose: () => void;
+}
+
 /**
  * RuntimeErrorDialog – informational MUI Dialog shown when the simulator
  * encounters a runtime error (e.g. integer overflow, unsupported syscall).
@@ -21,13 +34,12 @@ import errorImage from '../static/error-hires.png';
  * immediately when the error result arrives, *not* when the user dismisses
  * this dialog.  The dialog is purely informational and can be closed at any
  * time without side-effects.
- *
- * Props:
- *   open     – boolean, controls visibility.
- *   message  – string, the error message to display.
- *   onClose  – callback invoked when the user clicks OK or closes the dialog.
  */
-function RuntimeErrorDialog({ open, message, onClose }) {
+function RuntimeErrorDialog({
+  open,
+  message,
+  onClose,
+}: RuntimeErrorDialogProps): React.ReactElement {
   return (
     <Dialog
       id="runtime-error-dialog"

--- a/src/webapp/hooks/useExecutionController.ts
+++ b/src/webapp/hooks/useExecutionController.ts
@@ -1,10 +1,58 @@
-import React from 'react';
-import { executionReducer, initialExecState } from '../executionReducer';
+import { useReducer, useRef, useEffect, useCallback } from 'react';
+import {
+  executionReducer,
+  initialExecState,
+  type ExecState,
+  type ExecAction,
+} from '../executionReducer';
+import type { SimulatorResult, SimulatorWorker } from '../simulator/protocol';
 
 // The number of steps dispatched to the worker in each internal batch.
 // Kept here (not in Simulator.js) so the scheduling logic in updateState
 // can reference it without prop-drilling.
 const INTERNAL_STEPS_STRIDE = 50;
+
+// ---------------------------------------------------------------------------
+// Param and return types
+// ---------------------------------------------------------------------------
+
+/** Parameters accepted by useExecutionController. */
+export interface ExecutionControllerParams {
+  /** The augmented worker proxy created in index.js (stable across renders). */
+  worker: SimulatorWorker;
+  /** Bulk state updater from useSimulatorData. */
+  applyResultState: (result: SimulatorResult) => void;
+  /** Checksyntax-only updater from useSimulatorData. */
+  applyChecksyntaxResult: (result: SimulatorResult) => void;
+  /** Input-request setter from useSimulatorData. */
+  setInputRequest: (v: SimulatorResult | null) => void;
+  /** Milliseconds to insert between step batches (0 = no delay). */
+  executionDelayMs: number;
+  /**
+   * Called with a human-readable message when a runtime error result arrives
+   * (e.g. synchronous exception, unsupported syscall). The caller renders the
+   * RuntimeErrorDialog; execution is stopped here regardless, immediately.
+   */
+  onRuntimeError: (message: string) => void;
+}
+
+/** The public API returned by useExecutionController to Simulator.js. */
+export interface ExecutionControllerAPI {
+  /** Full execution state for consumers that need more than `executing`. */
+  execState: ExecState;
+  /** Convenience destructure of execState.executing. */
+  executing: boolean;
+  /** Dispatch for PAUSE_REQUESTED / INPUT_SUBMITTED. */
+  dispatch: React.Dispatch<ExecAction>;
+  /** Start run-all mode (worker runs batches until STOPPED). */
+  runCode: () => void;
+  /** Run exactly n steps (batched internally by INTERNAL_STEPS_STRIDE). */
+  stepCode: (n: number) => void;
+  /** Stop execution and reset the worker to READY. */
+  stopCode: () => void;
+  /** Called by clearCode() / restoreDefaultSample() in Simulator.js. */
+  notifyReset: () => void;
+}
 
 /**
  * useExecutionController — owns all execution-related state and side-effects.
@@ -12,7 +60,7 @@ const INTERNAL_STEPS_STRIDE = 50;
  * Responsibilities:
  *   - The execution reducer (execState / dispatch) that replaces the old
  *     stepsToRun / mustPause / runAll / executing useState quartet.
- *   - Batch scheduling: nextBatchTimeout ref, cancelPendingBatch,
+ *   - Batch scheduling: nextBatchTimeoutRef ref, cancelPendingBatch,
  *     scheduleNextBatch, and executionDelayRef (a ref mirror of the
  *     executionDelayMs setting so live delay changes take effect mid-run).
  *   - Worker 'message' subscription (workerHandlerRef pattern):
@@ -20,24 +68,6 @@ const INTERNAL_STEPS_STRIDE = 50;
  *     reassigned on every render so it always reads the latest closures.
  *   - updateState decision logic: after each result it decides whether to
  *     schedule another batch, halt, or surface a runtime error.
- *
- * Public API returned to Simulator.js:
- *   - execState   ({ stepsToRun, mustPause, runAll, executing })
- *   - executing   — convenience destructure
- *   - dispatch    — for PAUSE_REQUESTED, INPUT_SUBMITTED
- *   - runCode()   — starts run-all mode
- *   - stepCode(n) — runs n steps (batched by INTERNAL_STEPS_STRIDE)
- *   - stopCode()  — stops execution and resets the worker
- *   - notifyReset() — called by clearCode / restoreDefaultSample;
- *                     handles the controller side (cancel batch, dispatch
- *                     RESET, worker.reset(), clear inputRequest).
- *
- * @param {object} params
- * @param {object}   params.worker                  - worker proxy (stable prop)
- * @param {function} params.applyResultState         - from useSimulatorData
- * @param {function} params.applyChecksyntaxResult   - from useSimulatorData
- * @param {function} params.setInputRequest          - from useSimulatorData
- * @param {number}   params.executionDelayMs         - ms between step batches
  */
 export function useExecutionController({
   worker,
@@ -45,18 +75,12 @@ export function useExecutionController({
   applyChecksyntaxResult,
   setInputRequest,
   executionDelayMs,
-  // Called with a human-readable message when a runtime error result arrives
-  // (e.g. synchronous exception, unsupported syscall). The caller renders the
-  // RuntimeErrorDialog; execution is stopped here regardless, immediately.
   onRuntimeError,
-}) {
+}: ExecutionControllerParams): ExecutionControllerAPI {
   // ---------------------------------------------------------------------------
   // Execution state machine (replaces the four individual useState variables)
   // ---------------------------------------------------------------------------
-  const [execState, dispatch] = React.useReducer(
-    executionReducer,
-    initialExecState,
-  );
+  const [execState, dispatch] = useReducer(executionReducer, initialExecState);
   const { stepsToRun, mustPause, runAll, executing } = execState;
 
   // `executionDelayMs` is read inside async callbacks captured when a step
@@ -64,8 +88,8 @@ export function useExecutionController({
   // a ref so the delay applied between batches always reflects the *current*
   // setting, not the one active when "Run All" was pressed.  This lets the
   // user tweak the delay live, mid-run.
-  const executionDelayRef = React.useRef(executionDelayMs);
-  React.useEffect(() => {
+  const executionDelayRef = useRef<number>(executionDelayMs);
+  useEffect(() => {
     executionDelayRef.current = executionDelayMs;
   }, [executionDelayMs]);
 
@@ -76,28 +100,28 @@ export function useExecutionController({
   // Pending timeout id for a delayed follow-up batch. Stored in a ref so that
   // stopping the simulation cancels any batch sleeping between strides instead
   // of having it fire after `worker.reset()` and surface a spurious error.
-  const nextBatchTimeout = React.useRef(null);
+  const nextBatchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const cancelPendingBatch = React.useCallback(() => {
-    if (nextBatchTimeout.current !== null) {
-      clearTimeout(nextBatchTimeout.current);
-      nextBatchTimeout.current = null;
+  const cancelPendingBatch = useCallback(() => {
+    if (nextBatchTimeoutRef.current !== null) {
+      clearTimeout(nextBatchTimeoutRef.current);
+      nextBatchTimeoutRef.current = null;
     }
   }, []);
 
   // Schedule the next internal step batch, inserting the user-configured
   // execution delay so long runs are visually paced.  A delay of 0 ms (the
   // default) runs batches back-to-back, matching the pre-existing behaviour.
-  const scheduleNextBatch = React.useCallback(
-    (fn) => {
+  const scheduleNextBatch = useCallback(
+    (fn: () => void) => {
       cancelPendingBatch();
       const delay = executionDelayRef.current;
       if (delay <= 0) {
         fn();
         return;
       }
-      nextBatchTimeout.current = setTimeout(() => {
-        nextBatchTimeout.current = null;
+      nextBatchTimeoutRef.current = setTimeout(() => {
+        nextBatchTimeoutRef.current = null;
         fn();
       }, delay);
     },
@@ -108,13 +132,13 @@ export function useExecutionController({
   // Public operations
   // ---------------------------------------------------------------------------
 
-  const runCode = React.useCallback(() => {
+  const runCode = useCallback(() => {
     dispatch({ type: 'RUN_ALL_REQUESTED' });
     worker.step(INTERNAL_STEPS_STRIDE);
   }, [worker]);
 
-  const stepCode = React.useCallback(
-    (n) => {
+  const stepCode = useCallback(
+    (n: number) => {
       const toRun = Math.min(n, INTERNAL_STEPS_STRIDE);
       dispatch({ type: 'STEP_REQUESTED', stepsRemaining: n - toRun });
       worker.step(toRun);
@@ -122,13 +146,13 @@ export function useExecutionController({
     [worker],
   );
 
-  const stopCode = React.useCallback(() => {
+  const stopCode = useCallback(() => {
     // If a batch was sleeping between strides, cancel it.  In that case no
     // worker result is in flight to flip `executing` back off via
     // `updateState`, so we pass hadPendingBatch=true and the reducer clears
     // executing immediately.  When the worker is mid-step (hadPendingBatch
     // false), the upcoming result will see mustPause=true and clear executing.
-    const hadPendingBatch = nextBatchTimeout.current !== null;
+    const hadPendingBatch = nextBatchTimeoutRef.current !== null;
     cancelPendingBatch();
     dispatch({ type: 'STOP', hadPendingBatch });
     setInputRequest(null);
@@ -138,8 +162,8 @@ export function useExecutionController({
   // Called by clearCode() / restoreDefaultSample() in Simulator.js.
   // Handles the controller side: cancel any pending batch, dispatch RESET,
   // reset the worker, and clear the inputRequest dialog.
-  const notifyReset = React.useCallback(() => {
-    const hadPendingBatch = nextBatchTimeout.current !== null;
+  const notifyReset = useCallback(() => {
+    const hadPendingBatch = nextBatchTimeoutRef.current !== null;
     cancelPendingBatch();
     dispatch({ type: 'RESET', hadPendingBatch });
     setInputRequest(null);
@@ -153,7 +177,7 @@ export function useExecutionController({
   // `updateState` is a render-local function; it reads stepsToRun/runAll/mustPause
   // from the render closure (same semantics as the original Simulator.js code).
   // Defined before the workerHandlerRef assignment so there is no TDZ concern.
-  const updateState = (result) => {
+  const updateState = (result: SimulatorResult) => {
     applyResultState(result);
 
     // TODO: cleaner handling of error types. Checking the error message is a
@@ -220,9 +244,9 @@ export function useExecutionController({
   // the *real* handler body is reassigned on every render and therefore
   // always reads the latest closures (execState, scheduleNextBatch, …).
   // This is the same pattern as the existing keyboardHandlerRef.
-  const workerHandlerRef = React.useRef(null);
-  workerHandlerRef.current = (e) => {
-    const result = worker.parseResult(e.data);
+  const workerHandlerRef = useRef<((e: MessageEvent) => void) | null>(null);
+  workerHandlerRef.current = (e: MessageEvent) => {
+    const result = worker.parseResult(e.data as Record<string, unknown>);
 
     // For syntax check responses, only update parsing errors to avoid
     // unnecessary re-renders on the rest of the UI.
@@ -246,8 +270,12 @@ export function useExecutionController({
   // assignment, which was a side-effect during render — a React anti-pattern
   // that could silently drop messages during Strict-Mode double-invocations
   // and could not carry a cleanup.
-  React.useEffect(() => {
-    const handleMessage = (e) => workerHandlerRef.current(e);
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (workerHandlerRef.current) {
+        workerHandlerRef.current(e);
+      }
+    };
     worker.addEventListener('message', handleMessage);
     return () => worker.removeEventListener('message', handleMessage);
     // worker is a stable prop reference; include it so the linter is satisfied

--- a/src/webapp/hooks/useKeyboardShortcuts.ts
+++ b/src/webapp/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,37 @@
-import React from 'react';
+import { useRef, useEffect } from 'react';
 import { deriveLogicalState } from '../simulatorState';
+import type { CpuStatus, SimulatorResult } from '../simulator/protocol';
+import type { ITelemetryClient } from '../telemetry';
+
+// ---------------------------------------------------------------------------
+// Params type
+// ---------------------------------------------------------------------------
+
+/** Parameters accepted by useKeyboardShortcuts. */
+export interface KeyboardShortcutsParams {
+  /** CPU status from the worker result. */
+  status: CpuStatus;
+  /** True while the worker is actively computing steps. */
+  executing: boolean;
+  /** Non-null while the InputDialog is open waiting for user input. */
+  inputRequest: SimulatorResult | null;
+  /** Returns true when the current editor content is a syntactically valid program. */
+  isValidProgram: () => boolean;
+  /** Load the current editor code into the simulator. */
+  loadCode: () => void;
+  /** Start run-all mode. */
+  runCode: () => void;
+  /** Run n steps. */
+  stepCode: (n: number) => void;
+  /** Stop execution and reset the simulator. */
+  stopCode: () => void;
+  /** Pause an in-progress run (dispatches PAUSE_REQUESTED). */
+  pauseCode: () => void;
+  /** Multi-step count from the STEP_STRIDE setting. */
+  stepStride: number;
+  /** Telemetry client for keyboard-shortcut action tracking. */
+  appInsights: ITelemetryClient;
+}
 
 /**
  * useKeyboardShortcuts — registers a window-level keydown handler for the
@@ -10,19 +42,6 @@ import { deriveLogicalState } from '../simulatorState';
  * reads the latest closures (status, executing, inputRequest, …).  This is
  * the same workerHandlerRef / keyboardHandlerRef pattern used elsewhere in
  * the codebase.
- *
- * @param {object} params
- * @param {string}        params.status        - 'READY' | 'RUNNING' | 'STOPPED'
- * @param {boolean}       params.executing     - true while worker is computing
- * @param {object|null}   params.inputRequest  - non-null while InputDialog is open
- * @param {function}      params.isValidProgram - () => boolean
- * @param {function}      params.loadCode      - () => void
- * @param {function}      params.runCode       - () => void
- * @param {function}      params.stepCode      - (n: number) => void
- * @param {function}      params.stopCode      - () => void
- * @param {function}      params.pauseCode     - () => void (dispatch PAUSE_REQUESTED)
- * @param {number}        params.stepStride    - multi-step count from settings
- * @param {object}        params.appInsights   - telemetry client
  */
 export function useKeyboardShortcuts({
   status,
@@ -36,9 +55,9 @@ export function useKeyboardShortcuts({
   pauseCode,
   stepStride,
   appInsights,
-}) {
-  const keyboardHandlerRef = React.useRef(null);
-  keyboardHandlerRef.current = (e) => {
+}: KeyboardShortcutsParams): void {
+  const keyboardHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
+  keyboardHandlerRef.current = (e: KeyboardEvent) => {
     // Don't steal keys while a modal dialog is open (Help, Settings, Input).
     if (document.querySelector('[role="dialog"]')) return;
     const logicalState = deriveLogicalState(status, executing, inputRequest);
@@ -64,7 +83,7 @@ export function useKeyboardShortcuts({
           });
           runCode();
         } else if (logicalState === 'EXECUTING') {
-          appInsights.trackEvent({ name: 'pause', source: 'keyboard' });
+          appInsights.trackEvent({ name: 'pause', properties: { source: 'keyboard' } });
           pauseCode();
         }
         break;
@@ -103,8 +122,12 @@ export function useKeyboardShortcuts({
     }
   };
 
-  React.useEffect(() => {
-    const handleKeyDown = (e) => keyboardHandlerRef.current(e);
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (keyboardHandlerRef.current) {
+        keyboardHandlerRef.current(e);
+      }
+    };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);

--- a/src/webapp/hooks/useSimulatorData.ts
+++ b/src/webapp/hooks/useSimulatorData.ts
@@ -1,12 +1,22 @@
-import React from 'react';
+import { useState, useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
+import type {
+  SimulatorResult,
+  Registers,
+  Memory,
+  Statistics,
+  CpuStatus,
+  Pipeline,
+  ParsingError,
+  PipelineInstruction,
+} from '../simulator/protocol';
 
 /**
  * Returns true if the given parsingErrors array contains at least one actual
  * error (not just warnings).  Exported so the execution controller can reuse
  * the same logic when processing checksyntax responses.
  */
-export const hasRealErrors = (parsingErrors) => {
+export const hasRealErrors = (parsingErrors: ParsingError[] | null): boolean => {
   if (!parsingErrors) return false;
   return parsingErrors.some((e) => !e.isWarning);
 };
@@ -30,22 +40,24 @@ export const hasRealErrors = (parsingErrors) => {
  *   - Individual setters (setStdout, setParsingErrors, setInputRequest) for the
  *     few call sites in Simulator.js that need fine-grained control.
  *
- * @param {object} initialState - the initial simulator state passed by AppLoader.
+ * @param initialState - the initial simulator state passed by AppLoader.
  */
-export function useSimulatorData(initialState) {
-  const [registers, setRegisters] = React.useState(initialState.registers);
-  const [memory, setMemory] = React.useState(initialState.memory);
-  const [stats, setStats] = React.useState(initialState.statistics);
-  const [status, setStatus] = React.useState(initialState.status);
-  const [pipeline, setPipeline] = React.useState(initialState.pipeline);
-  const [parsingErrors, setParsingErrors] = React.useState(
+export function useSimulatorData(initialState: SimulatorResult) {
+  const [registers, setRegisters] = useState<Registers>(initialState.registers);
+  const [memory, setMemory] = useState<Memory>(initialState.memory);
+  const [stats, setStats] = useState<Statistics>(initialState.statistics);
+  const [status, setStatus] = useState<CpuStatus>(initialState.status);
+  const [pipeline, setPipeline] = useState<Pipeline>(initialState.pipeline);
+  const [parsingErrors, setParsingErrors] = useState<ParsingError[] | null>(
     initialState.parsingErrors,
   );
-  const [parsedInstructions, setParsedInstructions] = React.useState(
-    initialState.parsedInstructions,
-  );
-  const [stdout, setStdout] = React.useState('');
-  const [inputRequest, setInputRequest] = React.useState(null);
+  const [parsedInstructions, setParsedInstructions] = useState<
+    PipelineInstruction[] | null
+  >(initialState.parsedInstructions);
+  const [stdout, setStdout] = useState<string>('');
+  // inputRequest carries the full SimulatorResult when the worker requests
+  // stdin input (result.inputRequested === true). null means no pending input.
+  const [inputRequest, setInputRequest] = useState<SimulatorResult | null>(null);
 
   /**
    * Apply a full worker result (step / load / reset) to the data state.
@@ -55,7 +67,7 @@ export function useSimulatorData(initialState) {
    * a shallow-compare of props, so a stable reference means the memo'd panel
    * will not re-render even though we called the setter.
    */
-  const applyResultState = React.useCallback((result) => {
+  const applyResultState = useCallback((result: SimulatorResult) => {
     setRegisters((prev) =>
       isEqual(prev, result.registers) ? prev : result.registers,
     );
@@ -93,7 +105,7 @@ export function useSimulatorData(initialState) {
    * Only updates parsingErrors and parsedInstructions so that the rest of the
    * UI does not re-render unnecessarily on every keypress.
    */
-  const applyChecksyntaxResult = React.useCallback((result) => {
+  const applyChecksyntaxResult = useCallback((result: SimulatorResult) => {
     setParsingErrors((prev) =>
       isEqual(prev, result.parsingErrors) ? prev : result.parsingErrors,
     );

--- a/src/webapp/settings/schema.ts
+++ b/src/webapp/settings/schema.ts
@@ -1,4 +1,4 @@
-import { SettingKey } from './SettingKey';
+import { SettingKey, type SettingKeyType } from './SettingKey';
 
 /**
  * Supported setting types.
@@ -308,4 +308,82 @@ export function sanitize(key: string, raw: unknown): unknown {
   }
 
   return raw;
+}
+
+// ---------------------------------------------------------------------------
+// SettingValueMap — per-key type inference for useSetting<K>
+// ---------------------------------------------------------------------------
+
+/**
+ * The expanded-accordions object that controls which Simulator panels are
+ * open by default and after user interaction.
+ */
+export interface ExpandedAccordions {
+  stats: boolean;
+  pipeline: boolean;
+  registers: boolean;
+  memory: boolean;
+  stdout: boolean;
+  cache: boolean;
+  settings: boolean;
+}
+
+/**
+ * L1 cache configuration parameters (L1D and L1I share the same shape).
+ */
+export interface CacheConfig {
+  size: number;
+  blockSize: number;
+  associativity: number;
+}
+
+/**
+ * Per-stage pipeline colours (hex `#RRGGBB` strings).
+ * Mirrors the keys in `DEFAULT_PIPELINE_COLORS`.
+ */
+export interface PipelineColors {
+  IF: string;
+  ID: string;
+  EX: string;
+  MEM: string;
+  WB: string;
+  FPAdder: string;
+  FPMultiplier: string;
+  FPDivider: string;
+  Stall: string;
+}
+
+/** Allowed values for the `THEME_MODE` setting. */
+export type ThemeMode = 'auto' | 'light' | 'dark';
+
+/**
+ * Maps every `SettingKeyType` string value to its concrete TypeScript value
+ * type.  This is the source of truth used by `useSetting<K>` to give call
+ * sites a precisely-typed `[value, setValue, reset]` tuple without any casts.
+ *
+ * Adding a new setting: add a row here and a matching row in `SETTINGS_SCHEMA`.
+ */
+export interface SettingValueMap extends Record<SettingKeyType, unknown> {
+  // Editor / general UI
+  viMode: boolean;
+  fontSize: number;
+  accordionAlerts: boolean;
+  expandedAccordions: ExpandedAccordions;
+  // Cache
+  'cache.l1d': CacheConfig;
+  'cache.l1i': CacheConfig;
+  // CPU
+  forwarding: boolean;
+  delaySlot: boolean;
+  // Execution
+  stepStride: number;
+  executionDelayMs: number;
+  // Help dialog
+  'help.language': string;
+  // Editor content
+  editorCode: string;
+  // Pipeline widget colours
+  pipelineColors: PipelineColors;
+  // UI theme
+  themeMode: ThemeMode;
 }

--- a/src/webapp/settings/useSetting.ts
+++ b/src/webapp/settings/useSetting.ts
@@ -1,12 +1,15 @@
 import { useCallback, useMemo } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import { getSchema, sanitize } from './schema';
+import { getSchema, sanitize, type SettingValueMap } from './schema';
+import type { SettingKeyType } from './SettingKey';
 
 /**
  * Higher-level hook for a single persisted setting.
  *
  * Usage:
  *   const [viMode, setViMode, resetViMode] = useSetting(SettingKey.VI_MODE);
+ *   // viMode is inferred as `boolean`
+ *   // setViMode accepts `boolean | ((prev: boolean) => boolean)`
  *
  * Compared to the raw `useLocalStorage` primitive, this hook:
  *   - looks up the setting's declared type and default from `SETTINGS_SCHEMA`,
@@ -16,40 +19,53 @@ import { getSchema, sanitize } from './schema';
  *     doesn't match — the simulator stays usable even if localStorage is
  *     corrupted or was written by a different schema version;
  *   - for `object` settings, shallow-merges the stored value on top of the
- *     default so newly-added default keys appear for existing users.
+ *     default so newly-added default keys appear for existing users;
+ *   - for TypeScript call sites, returns a precisely-typed tuple via the
+ *     `SettingValueMap` index, giving real type inference without any casts.
  *
  * This mirrors the Java `ConfigStore` interface (typed getters, documented
  * defaults in a single place, graceful fallback).
  *
- * @param key  One of `SettingKey.*`.
+ * @param key  One of `SettingKey.*` (the string value, e.g. `'viMode'`).
  * @returns [value, setValue, reset]
- *
- * TODO(ts): The return type is `unknown` here because the schema's `default`
- * field is `unknown` (each key has a different concrete type). A per-key
- * overload map would give call sites concrete types; deferred to a later
- * phase when the component layer is converted.
  */
-export function useSetting(
-  key: string,
-): [unknown, (v: unknown) => void, () => void] {
+export function useSetting<K extends SettingKeyType>(
+  key: K,
+): [
+  SettingValueMap[K],
+  (
+    v: SettingValueMap[K] | ((prev: SettingValueMap[K]) => SettingValueMap[K]),
+  ) => void,
+  () => void,
+] {
   // Validate the key up front so typos fail fast instead of silently writing
   // random localStorage entries.
   const schema = getSchema(key);
 
-  // useLocalStorage is generic; we thread `unknown` here since the schema
-  // default can be any supported type. Call sites that need a concrete type
-  // should cast the returned value.  TODO(ts): remove casts when components
-  // are converted.
+  // useLocalStorage is generic; thread `unknown` here since the schema
+  // default can be any supported type. The public return type is narrowed by K
+  // via SettingValueMap, so callers always get a concrete type.
   const [raw, setRaw, resetRaw] = useLocalStorage<unknown>(key, schema.default);
 
-  const value = useMemo(() => sanitize(key, raw), [key, raw]);
+  const value = useMemo(
+    () => sanitize(key, raw) as SettingValueMap[K],
+    [key, raw],
+  );
 
   const setValue = useCallback(
-    (next: unknown) => {
+    (
+      next:
+        | SettingValueMap[K]
+        | ((prev: SettingValueMap[K]) => SettingValueMap[K]),
+    ) => {
       if (typeof next === 'function') {
         // Updater-function form: pass the sanitized current value so the
         // caller always receives the validated (not raw) previous state.
-        setRaw((prev: unknown) => (next as (prev: unknown) => unknown)(sanitize(key, prev)));
+        setRaw((prev: unknown) =>
+          (next as (prev: SettingValueMap[K]) => SettingValueMap[K])(
+            sanitize(key, prev) as SettingValueMap[K],
+          ),
+        );
       } else {
         setRaw(next);
       }

--- a/src/webapp/vendor.d.ts
+++ b/src/webapp/vendor.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal type declarations for third-party modules and non-JS assets that
+ * lack TypeScript type information and for which we have not added @types/*
+ * packages.
+ */
+
+// ---------------------------------------------------------------------------
+// lodash/isEqual
+//
+// lodash v4 ships without built-in TypeScript types and @types/lodash is
+// intentionally omitted to keep the lockfile stable.  Only the single
+// function used in useSimulatorData.ts is declared here.
+// ---------------------------------------------------------------------------
+
+declare module 'lodash/isEqual' {
+  /**
+   * Performs a deep comparison between two values to determine if they are
+   * equivalent.
+   */
+  const isEqual: (value: unknown, other: unknown) => boolean;
+  export default isEqual;
+}
+
+// ---------------------------------------------------------------------------
+// Static image assets (webpack file-loader / url-loader)
+//
+// webpack resolves `.png` imports to a URL string at build time.  Declare
+// the module shape so TypeScript doesn't reject `import foo from '*.png'`
+// in .tsx files.  (Previously these imports were only in .js files where
+// checkJs:false suppressed the check; .tsx files are fully type-checked.)
+// ---------------------------------------------------------------------------
+
+declare module '*.png' {
+  const url: string;
+  export default url;
+}
+
+declare module '*.jpg' {
+  const url: string;
+  export default url;
+}
+
+declare module '*.svg' {
+  const url: string;
+  export default url;
+}


### PR DESCRIPTION
## Summary

This PR continues the incremental TypeScript migration of the EduMIPS64 web UI, converting the three core hooks and three entry-level components, and implementing fully-typed `useSetting<K>`.

### Scope

**Hooks converted (`.js` → `.ts`)**
- `hooks/useSimulatorData.ts`: typed against `simulator/protocol.ts` — all state fields (`Registers`, `Memory`, `Statistics`, `CpuStatus`, `Pipeline`, `ParsingError[]`, `PipelineInstruction[]`) are explicit; `inputRequest` is `SimulatorResult | null`. The reference-preserving update pattern (lodash `isEqual` guard) is preserved and now type-visible.
- `hooks/useExecutionController.ts`: `ExecutionControllerParams` interface types the params object (`worker: SimulatorWorker`, typed callbacks, `executionDelayMs: number`, `onRuntimeError`); `ExecutionControllerAPI` types the return. Reuses `ExecState`/`ExecAction` from `executionReducer.ts` and `SimulatorWorker`/`SimulatorResult` from `protocol.ts`.
- `hooks/useKeyboardShortcuts.ts`: `KeyboardShortcutsParams` interface — `status: CpuStatus`, `inputRequest: SimulatorResult | null`, `appInsights: ITelemetryClient`.

**`SettingValueMap` design** (`settings/schema.ts` + `settings/useSetting.ts`)
- Added a `SettingValueMap` interface to `schema.ts` that maps each `SettingKey` string value to its concrete TypeScript type (e.g. `viMode → boolean`, `fontSize → number`, `expandedAccordions → ExpandedAccordions`, `cache.l1d → CacheConfig`, `themeMode → 'auto'|'light'|'dark'`). The interface extends `Record<SettingKeyType, unknown>` so the exhaustiveness is enforced by TypeScript.
- `useSetting.ts` is now `useSetting<K extends SettingKeyType>(key: K)` returning `[SettingValueMap[K], setter, reset]`. TypeScript call sites get precise inference with no casts; existing JS call sites are unchecked (`checkJs: false`) and continue to work.
- Three helper interfaces are exported from `schema.ts`: `ExpandedAccordions`, `CacheConfig`, `PipelineColors`. `ThemeMode` is exported as a union type.

**Entry components converted (`.js` → `.tsx`)**
- `components/AppErrorBoundary.tsx`: typed `AppErrorBoundaryProps` (optional `appInsights: ITelemetryClient`, `children: React.ReactNode`) and `AppErrorBoundaryState` (`error: Error | null`, `errorInfo: React.ErrorInfo | null`). `getDerivedStateFromError` now returns `Partial<AppErrorBoundaryState>`.
- `components/AppLoader.tsx`: `LoaderPhase = 'loading' | 'ready' | 'error'` discriminated union. `AppLoaderProps` types `worker: SimulatorWorker` and optional `appInsights: ITelemetryClient`. `AppLoaderState` uses `initialState: SimulatorResult | null`. Private methods use proper event types (`MessageEvent`, `ErrorEvent`).
- `components/RuntimeErrorDialog.tsx`: typed props (`open: boolean`, `message: string`, `onClose: () => void`).

**Supporting**
- `src/webapp/vendor.d.ts`: minimal type stubs for `lodash/isEqual` (avoids adding `@types/lodash` to keep the lockfile stable) and `*.png`/`*.jpg`/`*.svg` image asset imports (needed now that `.tsx` files are type-checked).

**Not converted this phase** (as specified): `Simulator.js`, `Code.js`, `index.js`, and all display components — those have larger prop surfaces and are saved for phase 3.

### Phase 3 covers
`Simulator.js`, `Code.js`, the display components (`Registers.js`, `Memory.js`, `Pipeline.js`, `Statistics.js`, `StdOut.js`, etc.), and `index.js` (which uses webpack DefinePlugin globals requiring a separate `declare const VERSION`).

### Verification numbers
- `npm run typecheck` (strict): clean — 0 errors
- `npm run test:unit`: 42/42 passed (3 test files)
- `npm run build-dbg` + `npm run build`: both compile; prod bundle contains `1.4.0-` version string
- Playwright e2e: **88 passed, 1 skipped** (same as master baseline)
- `npx -y npm@11 ci --ignore-scripts --no-audit --no-fund`: clean — no lockfile changes
- `npx eslint src/webapp`: no new errors vs master

🤖 Generated with [Claude Code](https://claude.com/claude-code)