### PR TITLE
CI: raise Pages deploy verification timeout (Jekyll builds now exceed 15 min)

### DIFF
--- a/.github/scripts/verify-pages-deploy.sh
+++ b/.github/scripts/verify-pages-deploy.sh
@@ -45,8 +45,12 @@ fi
 PAGES_API_BASE="https://api.github.com/repos/EduMIPS64/web.edumips.org/pages/builds"
 CDN_UI_JS="https://web.edumips.org/ui.js"
 
-# Phase 1: up to 15 minutes for Pages build to complete.
-BUILD_TIMEOUT=900
+# Phase 1: up to 35 minutes for the Pages build to complete. Legacy Jekyll
+# builds of this site have grown from ~100 s to >15 min as the site gained
+# per-commit candidate snapshots (a 15-minute budget caused a false-negative
+# verification on 2026-07-03 while the build was still 'building'). The
+# long-term fix is Actions-based deployment (issue #1913).
+BUILD_TIMEOUT=2100
 # Phase 2: up to 12 minutes for CDN propagation (max-age is 600 s).
 CDN_TIMEOUT=720
 # Seconds between poll attempts.


### PR DESCRIPTION
Tonight's promotion of `2bfcf1e2` succeeded, but the `Verify Pages deployment` step failed after its 15-minute Phase-1 budget expired while the legacy Jekyll build was still honestly `building` (it eventually completed) — a false negative. Build durations have grown ~100 s → 405 s → >15 min as the site accumulated per-commit candidate snapshots.

This raises the budget to 35 minutes and documents the growth. The structural fix is #1913 (Actions-based Pages deployment, which removes the Jekyll build entirely); this PR just stops the verifier from crying wolf until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)