### PR TITLE
CI: explicit Pages deploy dispatch after promote/rollback (webhook-loss hardening)

### DIFF
--- a/.github/scripts/verify-pages-deploy.sh
+++ b/.github/scripts/verify-pages-deploy.sh
@@ -91,12 +91,20 @@ TRIGGERED_REDISPATCH=false
 redispatch() {
     if [[ "${TRIGGERED_REDISPATCH}" == "false" ]]; then
         echo "  -> Re-dispatching the deploy workflow ..."
-        gh_api -X POST \
+        HTTP=$(curl -sS -o /tmp/dispatch-resp.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${PAT_WEBUI}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/json" \
             -d '{"ref":"master"}' \
-            "${ACTIONS_API_BASE}/workflows/${DEPLOY_WORKFLOW}/dispatches" > /dev/null \
-            && TRIGGERED_REDISPATCH=true \
-            || echo "  -> WARNING: re-dispatch failed (missing actions scope?); continuing to poll."
+            "${ACTIONS_API_BASE}/workflows/${DEPLOY_WORKFLOW}/dispatches" || echo "000")
+        if [[ "${HTTP}" == "204" ]]; then
+            TRIGGERED_REDISPATCH=true
+        else
+            echo "  -> WARNING: re-dispatch failed (HTTP ${HTTP}): $(cat /tmp/dispatch-resp.json 2>/dev/null | head -c 200)"
+            echo "  -> If HTTP is 403, PAT_WEBUI needs the Actions write scope"
+            echo "     (classic: 'workflow'; fine-grained: Actions: Read and write)."
+        fi
     fi
 }
 

--- a/.github/workflows/promote-web.yml
+++ b/.github/workflows/promote-web.yml
@@ -161,6 +161,33 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
 
+      # Explicitly trigger the Pages deploy workflow rather than relying on the
+      # push event alone: on 2026-07-03 GitHub dropped the push webhook for a
+      # promote commit and no deploy run was ever created. The dispatch is
+      # idempotent alongside the push trigger (concurrency group 'pages' in
+      # the deploy workflow serialises; a duplicate run deploys the same
+      # commit). Requires PAT_WEBUI to have Actions write scope; a 403 here
+      # is loud and actionable rather than a silent 10-minute verify timeout.
+      - name: Trigger Pages deploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          PAT_WEBUI: ${{ secrets.PAT_WEBUI }}
+        run: |
+          set -euo pipefail
+          HTTP=$(curl -sS -o /tmp/dispatch-resp.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${PAT_WEBUI}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d '{"ref":"master"}' \
+            "https://api.github.com/repos/EduMIPS64/web.edumips.org/actions/workflows/deploy-pages.yml/dispatches")
+          if [[ "${HTTP}" != "204" ]]; then
+            echo "::warning::Deploy dispatch returned HTTP ${HTTP}: $(head -c 200 /tmp/dispatch-resp.json 2>/dev/null)."
+            echo "::warning::If 403, grant PAT_WEBUI the Actions write scope (classic: 'workflow'; fine-grained: Actions R/W). Relying on the push trigger for this run."
+          else
+            echo "Deploy workflow dispatched."
+          fi
+
       - name: Verify Pages deployment
         if: steps.push.outputs.pushed == 'true'
         env:

--- a/.github/workflows/rollback-web.yml
+++ b/.github/workflows/rollback-web.yml
@@ -70,6 +70,33 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
 
+      # Explicitly trigger the Pages deploy workflow rather than relying on the
+      # push event alone: on 2026-07-03 GitHub dropped the push webhook for a
+      # promote commit and no deploy run was ever created. The dispatch is
+      # idempotent alongside the push trigger (concurrency group 'pages' in
+      # the deploy workflow serialises; a duplicate run deploys the same
+      # commit). Requires PAT_WEBUI to have Actions write scope; a 403 here
+      # is loud and actionable rather than a silent 10-minute verify timeout.
+      - name: Trigger Pages deploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          PAT_WEBUI: ${{ secrets.PAT_WEBUI }}
+        run: |
+          set -euo pipefail
+          HTTP=$(curl -sS -o /tmp/dispatch-resp.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${PAT_WEBUI}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d '{"ref":"master"}' \
+            "https://api.github.com/repos/EduMIPS64/web.edumips.org/actions/workflows/deploy-pages.yml/dispatches")
+          if [[ "${HTTP}" != "204" ]]; then
+            echo "::warning::Deploy dispatch returned HTTP ${HTTP}: $(head -c 200 /tmp/dispatch-resp.json 2>/dev/null)."
+            echo "::warning::If 403, grant PAT_WEBUI the Actions write scope (classic: 'workflow'; fine-grained: Actions R/W). Relying on the push trigger for this run."
+          else
+            echo "Deploy workflow dispatched."
+          fi
+
       - name: Verify Pages deployment
         if: steps.push.outputs.pushed == 'true'
         env:


### PR DESCRIPTION
Hardening from today's promotion of `0ac9e74d`: GitHub **dropped the push webhook** for the promote commit in the Pages repo — no deploy run was created at all. The new Phase-1 verification (#1924) did its job and failed loudly instead of reporting false success, but the recovery path also failed: the `workflow_dispatch` fallback was rejected because `PAT_WEBUI` lacks the Actions write scope. Production stayed stale until a manual dispatch (now done; production serves `1.4.0-188-g0ac9e74d` and validates).

Changes:
1. **Explicit `Trigger Pages deploy` step** in `promote-web.yml` and `rollback-web.yml`, right after the push — deploys no longer depend on webhook delivery. Idempotent with the push trigger (the deploy workflow's `pages` concurrency group serialises; a duplicate run redeploys the same commit). Non-204 responses warn with the exact missing scope instead of surfacing 10 minutes later as an opaque verify timeout.
2. **Diagnostics in `verify-pages-deploy.sh`**: the re-dispatch fallback logs HTTP status + response body and names the missing scope on 403.

## Action for @lupino3 (one minute, optional but recommended)
Grant `PAT_WEBUI` the Actions write scope — classic PAT: add `workflow`; fine-grained: **Actions: Read and write** on `web.edumips.org`. Until then, the explicit dispatch degrades to a loud warning and the push trigger remains the only lever, with the drift monitor (#1924) as the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)