### PR TITLE
Web UI: hide pruned versions from the About version list

### DIFF
--- a/src/test/webapp-unit/versionHistory.test.ts
+++ b/src/test/webapp-unit/versionHistory.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildVersionList } from '../../webapp/versionHistory';
+
+const entry = (n: number, opts: Partial<Record<string, unknown>> = {}) => ({
+  sha: `${n}`.repeat(40).slice(0, 40),
+  seq: n,
+  build: `1.4.0-${n}-gabc`,
+  promoted: false,
+  pushedAt: '2026-07-01T00:00:00Z',
+  ...opts,
+});
+
+const index = (versions: unknown[], current: string | null = null) => ({
+  current,
+  versions,
+});
+
+describe('buildVersionList', () => {
+  it('returns entries sorted by seq descending', () => {
+    const list = buildVersionList(index([entry(1), entry(3), entry(2)]), null);
+    expect(list.map((v) => v.seq)).toEqual([3, 2, 1]);
+  });
+
+  it('excludes pruned versions (their snapshot no longer exists)', () => {
+    // Regression: the retention policy marks old promoted versions with
+    // pruned=true and deletes their c/<sha>/ snapshot; the About tab used
+    // to render 404 links for them.
+    const list = buildVersionList(
+      index([
+        entry(3, { promoted: true }),
+        entry(2, { promoted: true, pruned: true }),
+        entry(1, { promoted: true, pruned: false }),
+      ]),
+      null,
+    );
+    expect(list.map((v) => v.seq)).toEqual([3, 1]);
+  });
+
+  it('flags the current version', () => {
+    const cur = entry(2, { promoted: true });
+    const list = buildVersionList(
+      index([entry(1), cur], cur.sha as string),
+      null,
+    );
+    expect(list.find((v) => v.isCurrent)?.seq).toBe(2);
+  });
+
+  it('returns [] for invalid data', () => {
+    expect(buildVersionList(null, null)).toEqual([]);
+    expect(buildVersionList({ versions: 'nope' }, null)).toEqual([]);
+  });
+});

--- a/src/webapp/versionHistory.ts
+++ b/src/webapp/versionHistory.ts
@@ -31,6 +31,13 @@ interface VersionEntry {
   promoted: boolean;
   promotedAt?: string;
   promotedBy?: string;
+  /**
+   * True when the retention policy deleted this version's c/<sha>/ snapshot
+   * (deploy-web-pages.py keeps the entry for the audit trail). Pruned
+   * versions have no content to link to and cannot be promoted or rolled
+   * back to.
+   */
+  pruned?: boolean;
 }
 
 /** The shape of a parsed versions.json file. */
@@ -120,7 +127,11 @@ export function buildVersionList(data: unknown, viewedSha: string | null): Versi
   if (!isValidVersions(data)) {
     return [];
   }
-  const sorted = [...data.versions].sort((a, b) => b.seq - a.seq);
+  // Pruned versions have no snapshot on disk: linking to them would 404 and
+  // they are not valid rollback/promote targets, so they are not displayed.
+  const sorted = [...data.versions]
+    .filter((entry) => entry.pruned !== true)
+    .sort((a, b) => b.seq - a.seq);
   return sorted.map((entry) => ({
     sha: entry.sha,
     shortsha: entry.shortsha ?? entry.sha.slice(0, 7),


### PR DESCRIPTION
Fixes the 404s Andrea spotted in the About tab: the retention policy (#1909, `KEEP_PROMOTED=10`) deletes old promoted snapshots but keeps their `versions.json` entries with `pruned: true` for the audit trail — and the About tab was never taught about the flag, so it rendered `/c/<sha>/` links to deleted content (6 of them in production right now, visible because we promoted 8 times in two days).

`buildVersionList` now filters out `pruned` entries, so the list shows exactly the versions that exist — i.e. the valid rollback/promote targets. New `versionHistory` unit tests cover the filter (46 unit tests total).

On rollback depth: the policy keeps the **10 most recent promoted** snapshots (plus current), so up to 9 older versions remain reachable — `rollback-web` steps to the newest older one, and re-running it (or promoting any listed sha directly) reaches the rest. If you want the window to span more calendar time even during rapid-promotion days like today, bumping `KEEP_PROMOTED` in `deploy-web-pages.py` is a one-line change — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)