### PR TITLE
webui: serve the GWT worker.js from out/web on the dev server

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,6 +42,49 @@ function copyDocsPlugin(): Plugin {
   };
 }
 
+// Serve the GWT-compiled simulator core (worker.js) from out/web on the dev
+// server.  Vite's root is src/webapp, but worker.js is a build artifact that
+// lives in out/web (produced by `gradlew assembleWebApp`), so `new
+// Worker("worker.js")` would otherwise hit the SPA fallback and receive
+// index.html — surfacing as "Failed to load the EduMIPS64 simulator core /
+// Unexpected token '<'".  This middleware bridges that gap for `npm start`;
+// the production build already emits worker.js next to ui.js, so it is
+// dev-only (apply: 'serve').
+function serveGwtWorkerPlugin(): Plugin {
+  // The only artifacts the worker entrypoint needs at runtime.  worker.js is
+  // self-contained; clear.cache.gif is included for completeness.
+  const CONTENT_TYPES: Record<string, string> = {
+    '/worker.js': 'application/javascript',
+    '/clear.cache.gif': 'image/gif',
+  };
+  return {
+    name: 'serve-gwt-worker',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url || '').split('?')[0];
+        const contentType = CONTENT_TYPES[pathname];
+        if (!contentType) {
+          return next();
+        }
+        const file = path.resolve(__dirname, 'out/web', pathname.slice(1));
+        if (!fs.existsSync(file)) {
+          // Fall through so the user still gets a clear 404 rather than the
+          // HTML fallback; the console error then points at the missing
+          // build artifact instead of a confusing syntax error.
+          res.statusCode = 404;
+          res.end(
+            `${pathname} not found in out/web — run \`./gradlew assembleWebApp\` to build the GWT worker.`,
+          );
+          return;
+        }
+        res.setHeader('Content-Type', contentType);
+        fs.createReadStream(file).pipe(res);
+      });
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => {
   const isDev = mode === 'development';
   return {
@@ -121,6 +164,10 @@ export default defineConfig(({ mode }) => {
         : []),
 
       copyDocsPlugin(),
+
+      // Dev-only: serve the GWT worker.js from out/web so `npm start` can
+      // load the simulator core (see plugin comment above).
+      serveGwtWorkerPlugin(),
     ],
   };
 });


### PR DESCRIPTION
## Problem

`npm start` (the Vite dev server, on `http://localhost:5173`) cannot load the simulator core. The page shows:

> **Failed to load the EduMIPS64 simulator core**
> Uncaught SyntaxError: Unexpected token '<'

**Root cause:** Vite's root is `src/webapp`, but the GWT-compiled `worker.js` is a build artifact that lives in `out/web` (gitignored, produced by `./gradlew assembleWebApp`). The dev server had no middleware/proxy to reach it, so `new Worker("worker.js")` fell through to the SPA fallback and got `index.html` back (content-type `text/html`) — the browser then tried to parse HTML as the worker script and threw `Unexpected token '<'`.

This affected the dev-server workflow only. The `build-dbg` + static-serve path (what CI and the Playwright suite use) always worked, because the production build emits `worker.js` next to `ui.js` in `out/web`.

## Fix

A dev-only Vite plugin (`apply: 'serve'`) that serves `/worker.js` (and `/clear.cache.gif`) from `out/web`. If the artifact is missing, it returns a `404` with a hint to run `./gradlew assembleWebApp`, so a missing build points at the real cause instead of the confusing syntax error.

- **Production build unaffected** — the plugin is `apply: 'serve'`, and the build already emits `worker.js`. Verified `npm run build-dbg` still exits 0 with `worker.js` preserved in `out/web`.
- **Verified on 5173** — `/worker.js` now returns `application/javascript`, and a fresh headless load shows no error banner and no console errors.

## Caveat for contributors

The dev server serves the **pre-built** `worker.js`, so changes to the Java core still require `./gradlew assembleWebApp` to show up on 5173 — Vite only live-reloads the TypeScript/React side. (No change from today's reality; this just makes the core load at all.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)