### PR TITLE
fix(web): pin monaco-editor to 0.52.2 to prevent lockfile drift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/material": "^9.0.0",
         "express": "^5.2.1",
         "lodash": "^4.17.19",
+        "monaco-editor": "0.52.2",
         "monaco-vim": "^0.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -6161,8 +6162,7 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/monaco-vim": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/material": "^9.0.0",
     "express": "^5.2.1",
     "lodash": "^4.17.19",
+    "monaco-editor": "0.52.2",
     "monaco-vim": "^0.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary

- `monaco-editor` is currently only a transitive/peer dependency (pulled in by `@monaco-editor/react@4.7.0` and `monaco-vim`, peer range `< 1`), and it resolves in `package-lock.json` to `0.52.2`.
- Renovate's lockfile-maintenance PR (#1948) floats the resolved transitive version to `0.55.1`. monaco 0.53+ restructured its ESM layout, which breaks our deep imports of `monaco-editor/esm/vs/editor/editor.api` (used in `src/webapp/components/Code.tsx`, `src/webapp/components/Simulator.tsx`, `src/webapp/monacoSetup.ts`) and the side-effect import of `monaco-editor/esm/vs/editor/editor.main` (`monacoSetup.ts`), failing with TS2307/TS2882.
- Fix: pin `monaco-editor` as a **direct, exact** dependency (`"0.52.2"`, no caret) in `package.json`, so the resolved version can't move underneath us regardless of what its peers request. This unblocks #1948 (whose other lockfile updates are fine) by making the monaco version stable.
- A real migration to monaco 0.55+ (adopting its new ESM import layout) is deliberate future work, not part of this PR.

Note on Renovate config: with monaco now a direct, exact dependency, `lockFileMaintenance` should no longer be able to bump it silently — a version change now requires its own Renovate PR that bumps the exact pin, which we can review and gate on the ESM migration. No `renovate.json5` changes were made; this can be revisited if Renovate still finds a way to touch it.

## Verification

- `npm install` — updated `package-lock.json`; diff is minimal (adds the direct `monaco-editor` entry, removes the stale `"peer": true` marker on the existing 0.52.2 lockfile entry).
- `npm ls monaco-editor` — resolves to `0.52.2` everywhere (deduped) for both `@monaco-editor/react` and `monaco-vim`.
- `npm run typecheck` (`tsc --noEmit`, same command used in CI's "Web UI coverage" job) — passes.
- `npm run build-dbg` (`vite build --mode development`) — builds successfully.

## Test plan

- [x] `npm install` regenerates lockfile with monaco-editor pinned and deduped to 0.52.2
- [x] `npm run typecheck` passes
- [x] `npm run build-dbg` succeeds
- [ ] CI green on this PR

Ref #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)