### PR TITLE
test(web): fix race in cycles-widget run-to-completion spec

### DIFF
--- a/src/test/webapp/cycles-widget.spec.js
+++ b/src/test/webapp/cycles-widget.spec.js
@@ -114,16 +114,22 @@ test('the diagram survives a run to completion and resets on reload', async ({
   // When execution finishes, the widget must report the final cycle count
   // (matching the Stats panel) and still contain one row per instruction
   // fetch. The exact count depends on stall timing, so just require > 5.
-  await expect(page.getByTestId('cycles-widget')).toHaveAttribute(
-    'data-time',
-    /^\d+$/,
-  );
+  //
+  // The widget's `data-time` attribute and the Stats panel's `#stat-cycles`
+  // text are updated by separate re-renders, so reading them as two
+  // one-shot snapshots races: one can be captured mid-run (e.g. "1") while
+  // the other has already reached the final count (e.g. "10"). Re-read both
+  // together and retry until they agree, so the comparison only happens once
+  // the run has well and truly settled.
+  const widget = page.getByTestId('cycles-widget');
   const stats = page.locator('#stat-cycles');
-  const statCycles = await stats.textContent();
-  await expect(page.getByTestId('cycles-widget')).toHaveAttribute(
-    'data-time',
-    statCycles.trim(),
-  );
+  let statCycles;
+  await expect(async () => {
+    const widgetTime = await widget.getAttribute('data-time');
+    statCycles = (await stats.textContent()).trim();
+    expect(widgetTime).toMatch(/^\d+$/);
+    expect(widgetTime).toBe(statCycles);
+  }).toPass({ timeout: 30000 });
 
   // Re-loading the program resets the CycleBuilder: the diagram restarts
   // from the first fetch (cycle 1, one row) rather than keeping the history


### PR DESCRIPTION
## Summary

Fixes a flaky Playwright test in `src/test/webapp/cycles-widget.spec.js`: **"the diagram survives a run to completion and resets on reload"**. This test flaked on today's master CI push, [run 28929913080](https://github.com/EduMIPS64/edumips64/actions/runs/28929913080).

### The race

The test clicked `#run-button`, then:
1. read `#stat-cycles` textContent into a variable, then
2. separately asserted the cycles-widget's `data-time` attribute equals that value.

Because the two elements are updated by independent re-renders, these were effectively two separate point-in-time snapshots. In the observed failure, `statCycles` was captured as `"1"` while `data-time` had already advanced to `"10"` (the run had actually completed by the time the second read happened) — a classic read-then-assert race, not a product bug.

### The fix

Replace the two one-shot reads with a single `expect(async () => {...}).toPass({ timeout: 30000 })` block that re-reads *both* `data-time` and `#stat-cycles` together on every retry, and only succeeds once they agree on the same numeric value. This removes the window where one value can be stale relative to the other, regardless of which element re-renders first.

No product code was touched — this is a test-only change.

## Test plan

- [x] `npm run build-dbg`, served `out/web` locally, ran the spec against Chromium with `PLAYWRIGHT_TARGET_URL`/`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` — all 4 tests pass.
- [x] Ran the full spec with `--repeat-each=10` (40 test executions across all 4 cases, including the target test 10/10) — **40 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>