### PR TITLE
chore: fix Codacy issues and align its tools with project conventions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  // JavaScript/TypeScript linting is done by Biome (biome.json), enforced
+  // locally and in CI via `npm run lint`. This file exists only so that
+  // Codacy's ESLint tool uses it instead of its default patterns, which
+  // conflict with our Biome style (e.g. it demands double quotes while
+  // Biome enforces single quotes). No rules are enabled on purpose.
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.github/scripts/verify-pages-deploy.sh
+++ b/.github/scripts/verify-pages-deploy.sh
@@ -101,7 +101,7 @@ redispatch() {
         if [[ "${HTTP}" == "204" ]]; then
             TRIGGERED_REDISPATCH=true
         else
-            echo "  -> WARNING: re-dispatch failed (HTTP ${HTTP}): $(cat /tmp/dispatch-resp.json 2>/dev/null | head -c 200)"
+            echo "  -> WARNING: re-dispatch failed (HTTP ${HTTP}): $(head -c 200 /tmp/dispatch-resp.json 2>/dev/null)"
             echo "  -> If HTTP is 403, PAT_WEBUI needs the Actions write scope"
             echo "     (classic: 'workflow'; fine-grained: Actions: Read and write)."
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,12 @@ jobs:
 
   # Run web UI Playwright tests locally with Istanbul coverage instrumentation.
   # Lint all Markdown files (markdownlint-cli2; rules in .markdownlint.json,
-  # globs/ignores in .markdownlint-cli2.jsonc). A dedicated job so markdown
-  # feedback lands fast, without waiting for the web build.
+  # globs/ignores in .markdownlint-cli2.jsonc) and all shell scripts
+  # (shellcheck, preinstalled on ubuntu runners; .squad/ is agent scaffolding
+  # and excluded, mirroring .codacy.yaml). A dedicated job so this feedback
+  # lands fast, without waiting for the web build.
   lint-docs:
-    name: Lint Markdown
+    name: Lint Markdown and shell scripts
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -127,6 +129,9 @@ jobs:
 
       - name: Lint Markdown
         run: npm run lint:md
+
+      - name: Lint shell scripts
+        run: git ls-files '*.sh' | grep -v '^\.squad/' | xargs shellcheck
 
   # The coverage report is rendered as a Markdown table and published to this
   # run's job summary. No secrets are used here.

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,8 @@
+# Prospector configuration, read by Codacy for the Python scripts in
+# .github/scripts/ and utils/. Docstring conventions are not enforced in
+# this project (most Python files are small internal tools and tests).
+doc-warnings: false
+
+mccabe:
+  options:
+    max-complexity: 15

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "rule-empty-line-before": [
+      "always-multi-line",
+      { "except": ["first-nested"], "ignore": ["after-comment"] }
+    ],
+    "comment-empty-line-before": [
+      "always",
+      { "except": ["first-nested"], "ignore": ["stylelint-commands"] }
+    ]
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,16 @@
 /*
  * EduMIPS64 Gradle build configuration
  */
+// detekt rules that don't add signal in a Gradle build script: helper
+// functions need no KDoc, repeated literals are task/path names, and
+// catching Exception around optional Xvfb startup is intentional.
+@file:Suppress(
+    "UndocumentedPublicFunction",
+    "StringLiteralDuplication",
+    "LabeledExpression",
+    "TooGenericExceptionCaught",
+)
+
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import ru.vyarus.gradle.plugin.python.task.PythonTask

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -14,6 +14,8 @@
 
 [Unit tests](#unit-tests)
 
+[Linting and static analysis](#linting-and-static-analysis)
+
 [Compiling under Windows](#windows)
 
 [Compiling under Mac OSX](#mac-os-x)
@@ -525,6 +527,30 @@ appear in assembly source (for example `BUBBLE`, which the pipeline
 inserts to represent stalls, and `DDIV3`, which is the Java class name
 for the 3-operand form of the `DDIV` mnemonic). Only extend this list
 for entries that are genuinely not reachable from MIPS64 assembly.
+
+## Linting and static analysis
+
+Lint checks run both locally/in CI and on [Codacy](https://app.codacy.com/gh/EduMIPS64/edumips64),
+which analyzes every PR. Codacy reads the tool configuration files committed
+at the repo root, so the two always agree:
+
+- **JavaScript/TypeScript**: Biome (`biome.json`), run via `npm run lint`.
+  `.eslintrc.json` is a deliberately empty ESLint config whose only purpose
+  is to stop Codacy's ESLint from applying defaults that conflict with Biome.
+- **Markdown**: markdownlint (`.markdownlint.json` for rules,
+  `.markdownlint-cli2.jsonc` for globs), run via `npm run lint:md`.
+- **Shell**: shellcheck, run in the `lint-docs` CI job.
+- **Java**: PMD with the curated ruleset in `ruleset.xml` (Codacy only; the
+  ruleset documents why the excluded rules don't fit this codebase).
+- **Python**: Prospector (`.prospector.yaml`), plus Pylint and Bandit with
+  targeted inline suppressions.
+- **CSS**: Stylelint (`.stylelintrc.json`).
+- **Kotlin (build scripts)**: detekt, with file-level suppressions in
+  `build.gradle.kts`.
+
+When Codacy flags something that contradicts a deliberate project convention,
+prefer updating the relevant config file (with a comment explaining why) over
+churning the code.
 
 ## Windows
 

--- a/docs/user/en/src/conf.py
+++ b/docs/user/en/src/conf.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.abspath("../.."))
 from common_conf import *  # noqa: F401, F403  -- re-export Sphinx config defaults
 
 language = "en"
-copyright = u'2011, Andrea Spadaccini (and the EduMIPS64 development team)'
+copyright = u'2011, Andrea Spadaccini (and the EduMIPS64 development team)'  # pylint: disable=redefined-builtin -- name required by Sphinx
 man_pages = [
     ('index', 'edumips64', u'EduMIPS64 Documentation',
      [u'Andrea Spadaccini (and the EduMIPS64 development team)'], 1)

--- a/docs/user/it/src/conf.py
+++ b/docs/user/it/src/conf.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.abspath("../.."))
 from common_conf import *  # noqa: F401, F403  -- re-export Sphinx config defaults
 
 language = "it"
-copyright = u'2011, Andrea Spadaccini ed il team di sviluppo di EduMIPS64'
+copyright = u'2011, Andrea Spadaccini ed il team di sviluppo di EduMIPS64'  # pylint: disable=redefined-builtin -- name required by Sphinx
 man_pages = [
     ('index', 'edumips64', u'Manuale di EduMIPS64',
      [u'Andrea Spadaccini ed il team di sviluppo di EduMIPS64 - traduzione di Simona Ullo'], 1)

--- a/electron/gen_electron_app_linux.sh
+++ b/electron/gen_electron_app_linux.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -rf ./dist/WebEduMips64-linux-x64
 cp index.js ..
 npx @electron/packager ../ WebEdumips64 --platform=linux --arch=x64 --out dist

--- a/electron/gen_electron_app_macos.sh
+++ b/electron/gen_electron_app_macos.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -rf ./dist/WebEduMips64-darwin-arm64
 cp index.js ..
 npx @electron/packager ../ WebEduMips64 --asar --platform=darwin --arch=arm64 --out dist

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="EduMIPS64"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+  <description>
+    PMD ruleset for EduMIPS64, read by Codacy in place of its default
+    pattern selection. Only rules that are actionable and compatible with
+    the project's conventions are enabled. Deliberately excluded:
+    - Naming rules (MethodNamingConventions, ClassNamingConventions):
+      pipeline-stage methods (IF/ID/EX/MEM/WB) and MIPS instruction class
+      names (e.g. ADD_D, ALU_IType) are intentional domain naming, and
+      test methods use descriptive snake_case.
+    - UnusedPrivateMethod: false positives on picocli @Command methods
+      invoked via reflection (e.g. utils/cli/ShowCommand.java).
+    - UnusedPrivateField: false positives on fields used from Swing inner
+      classes (GUICode, GUIData, GUIRegisters).
+    - Refactoring-level rules (NPathComplexity, AvoidReassigningParameters,
+      CollapsibleIfStatements, SingularField, ...): not actionable as lint
+      signal on this codebase; complexity is addressed in code review.
+  </description>
+
+  <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="category/java/design.xml/SimplifyBooleanExpressions"/>
+  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+  <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange"/>
+  <rule ref="category/java/performance.xml/StringInstantiation"/>
+</ruleset>

--- a/scripts/edumips64-snap-wrapper.sh
+++ b/scripts/edumips64-snap-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-$SNAP/usr/lib/jvm/java-17-openjdk-$SNAP_ARCH/bin/java -Dfile.encoding=UTF8 -Djava.util.prefs.userRoot="$SNAP_USER_DATA" -jar $SNAP/jar/edumips64.jar $*
+"$SNAP/usr/lib/jvm/java-17-openjdk-$SNAP_ARCH/bin/java" -Dfile.encoding=UTF8 -Djava.util.prefs.userRoot="$SNAP_USER_DATA" -jar "$SNAP/jar/edumips64.jar" "$@"

--- a/src/main/java/org/edumips64/CliRunner.java
+++ b/src/main/java/org/edumips64/CliRunner.java
@@ -53,7 +53,7 @@ public class CliRunner {
       runReplLoop(cli, commandLine);
 
     } catch (Exception e) {
-      org.edumips64.utils.cli.Cli.printErrorMessage(e);
+      Cli.printErrorMessage(e);
       System.exit(1);
     }
   }

--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -46,6 +46,7 @@ import org.edumips64.utils.CycleBuilder;
 import org.edumips64.utils.JavaPrefsConfigStore;
 import org.edumips64.utils.MetaInfo;
 import org.edumips64.utils.cli.Args;
+import org.edumips64.utils.cli.Banner;
 import org.edumips64.utils.cli.Version;
 import org.edumips64.utils.io.LocalFileUtils;
 import org.edumips64.utils.io.LocalWriter;
@@ -135,9 +136,9 @@ public class Main {
 
   private static void showVersion(Args cliArgs) {
     if (cliArgs != null && cliArgs.isNoBanner()) {
-      org.edumips64.utils.cli.Banner.printCompact(System.out);
+      Banner.printCompact(System.out);
     } else {
-      org.edumips64.utils.cli.Banner.print(System.out);
+      Banner.print(System.out);
     }
   }
 

--- a/src/main/java/org/edumips64/core/FCSRRegister.java
+++ b/src/main/java/org/edumips64/core/FCSRRegister.java
@@ -138,6 +138,8 @@ public class FCSRRegister extends BitSet32 {
       case TOWARDS_MINUS_INFINITY:
         setBits("11", FCSR_RM_FIELD_INIT);
         break;
+      default:
+        break;
     }
   }
 
@@ -161,6 +163,8 @@ public class FCSRRegister extends BitSet32 {
           break;
         case INVALID_OPERATION:
           setFCSREnables("V", (value) ? 1 : 0);
+          break;
+        default:
           break;
       }
     } catch (IrregularStringOfBitsException e) {

--- a/src/main/java/org/edumips64/core/Register.java
+++ b/src/main/java/org/edumips64/core/Register.java
@@ -137,7 +137,7 @@ public class Register extends BitSet64 {
 
 
   public String toString() {
-    String s = new String();
+    String s = "";
 
     try {
       s = getHexString();

--- a/src/main/java/org/edumips64/core/StringFormatException.java
+++ b/src/main/java/org/edumips64/core/StringFormatException.java
@@ -30,8 +30,5 @@ package org.edumips64.core;
  */
 public class StringFormatException extends Exception {
   private static final long serialVersionUID = 797705026033533756L;
-
-  public StringFormatException() {
-  }
 }
 

--- a/src/main/java/org/edumips64/core/SymbolTable.java
+++ b/src/main/java/org/edumips64/core/SymbolTable.java
@@ -125,7 +125,7 @@ public class SymbolTable {
   }
 
   public String toString() {
-    String output = new String();
+    String output = "";
     output += "\nInstructions:\n";
     for(Map.Entry<String, Integer> entry : instr_labels.entrySet()) {
       output += entry.getKey() + ": " + entry.getValue() + "\n";

--- a/src/main/java/org/edumips64/core/fpu/FPExponentTooLargeException.java
+++ b/src/main/java/org/edumips64/core/fpu/FPExponentTooLargeException.java
@@ -29,7 +29,4 @@ package org.edumips64.core.fpu;
 public class FPExponentTooLargeException extends Exception {
   private static final long serialVersionUID = -5339487049447646349L;
 
-  public FPExponentTooLargeException() {
-  }
-
 }

--- a/src/main/java/org/edumips64/core/fpu/FPInstructionUtils.java
+++ b/src/main/java/org/edumips64/core/fpu/FPInstructionUtils.java
@@ -246,8 +246,8 @@ public class FPInstructionUtils {
       // At this point operands can be added and if an overflow or an underflow occurs
       // and if exceptions are activated then trap else results are returned
       MathContext mc = new MathContext(1000, RoundingMode.HALF_EVEN);
-      BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false)));
-      BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false)));
+      BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false))); // NOPMD - exact binary value of the double is intended
+      BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false))); // NOPMD - exact binary value of the double is intended
       BigDecimal result = operand1.add(operand2, mc);
 
       //checking for underflows or overflows are performed inside the doubleToBin method (if relative traps are disabled output is returned)
@@ -312,8 +312,8 @@ public class FPInstructionUtils {
     //at this point operands can be subtracted and if an overflow or an underflow occurs
     //and if exceptions are activated then a trap happens else results are returned
     MathContext mc = new MathContext(1000, RoundingMode.HALF_EVEN);
-    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false)));
-    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false)));
+    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false))); // NOPMD - exact binary value of the double is intended
+    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false))); // NOPMD - exact binary value of the double is intended
 
     BigDecimal result = operand1.subtract(operand2, mc);
     //checking for underflows or overflows are performed inside the doubleToBin method (if the relative traps are disabled the output is returned)
@@ -373,8 +373,8 @@ public class FPInstructionUtils {
     //at this point operands can be multiplied and if an overflow or an underflow occurs
     //and if exceptions are activated then a trap happens else results are returned
     MathContext mc = new MathContext(1000, RoundingMode.HALF_EVEN);
-    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false)));
-    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false)));
+    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false))); // NOPMD - exact binary value of the double is intended
+    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false))); // NOPMD - exact binary value of the double is intended
 
     BigDecimal result = operand1.multiply(operand2, mc);
 
@@ -443,8 +443,8 @@ public class FPInstructionUtils {
     //at this point operands can be divided and if an  underflow occurs
     //and if exceptions are activated then a trap happens else results are returned
     MathContext mc = new MathContext(1000, RoundingMode.HALF_EVEN);
-    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false)));
-    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false)));
+    BigDecimal operand1 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value1, false))); // NOPMD - exact binary value of the double is intended
+    BigDecimal operand2 = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value2, false))); // NOPMD - exact binary value of the double is intended
 
     BigDecimal result = operand1.divide(operand2, mc);
 
@@ -575,6 +575,8 @@ public class FPInstructionUtils {
           return 1;
         case '1':
           return -1;
+        default:
+          break;
       }
     }
 
@@ -649,7 +651,7 @@ public class FPInstructionUtils {
     final int INT_PART = 0;
     final int DEC_PART = 1;
 
-    BigDecimal bd = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value, false)));
+    BigDecimal bd = new BigDecimal(Double.longBitsToDouble(Converter.binToLong(value, false))); // NOPMD - exact binary value of the double is intended
     String plainValue = bd.toPlainString();
     //removing the sign
     plainValue = plainValue.replaceFirst("-", "");
@@ -694,6 +696,8 @@ public class FPInstructionUtils {
           if (bd.doubleValue() < 0) {
             int_part_value++;
           }
+          break;
+        default:
           break;
       }
 

--- a/src/main/java/org/edumips64/core/fpu/FPPipeline.java
+++ b/src/main/java/org/edumips64/core/fpu/FPPipeline.java
@@ -90,6 +90,8 @@ public class FPPipeline {
           return (adder.getFuncUnit().get(Constants.FPAdderStatus.A3) != null);
         case 4:
           return (adder.getFuncUnit().get(Constants.FPAdderStatus.A4) != null);
+        default:
+          break;
       }
 
     if (funcUnit.compareToIgnoreCase("MULTIPLIER") == 0)

--- a/src/main/java/org/edumips64/core/is/OR.java
+++ b/src/main/java/org/edumips64/core/is/OR.java
@@ -60,7 +60,7 @@ public class OR extends ALU_RType {
       rtbit = rt.charAt(i) == '1' ? true : false;
 
       resbit = rsbit || rtbit;
-      outputstring += (resbit == true ? 1 : 0);
+      outputstring += (resbit ? 1 : 0);
     }
 
     //saving bitwise AND result into a temporary register

--- a/src/main/java/org/edumips64/core/is/SUB.java
+++ b/src/main/java/org/edumips64/core/is/SUB.java
@@ -69,7 +69,7 @@ public class SUB extends ALU_RType {
     } else {
       //performing sign extension
       outputstring = outputstring.substring(1, 33);
-      String filledOutputstring = new String(outputstring);
+      String filledOutputstring = outputstring;
 
       for (int i = 0; i < 32; i++) {
         filledOutputstring = outputstring.charAt(0) + filledOutputstring;

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -521,7 +521,7 @@ public class Parser {
 
               //timmy
               for (int timmy = 0; timmy < deprecateInstruction.length; timmy++) {
-                if (deprecateInstruction[timmy].toUpperCase().equals(line.substring(column, end).toUpperCase())) {
+                if (deprecateInstruction[timmy].equalsIgnoreCase(line.substring(column, end))) {
                   errors.addWarning("WINMIPS64_NOT_MIPS64", row, column + 1, line);
                 }
               }

--- a/src/main/java/org/edumips64/ui/swing/ErrorDialog.java
+++ b/src/main/java/org/edumips64/ui/swing/ErrorDialog.java
@@ -23,6 +23,7 @@
 package org.edumips64.ui.swing;
 
 import org.edumips64.core.parser.ParserException;
+import org.edumips64.ui.swing.img.IMGLoader;
 import org.edumips64.utils.CurrentLocale;
 import org.edumips64.utils.ConfigStore;
 
@@ -103,7 +104,7 @@ public class ErrorDialog extends JDialog {
 
     try {
       ImageIcon mainImageIcon = new ImageIcon(
-                           org.edumips64.ui.swing.img.IMGLoader.getImage(
+                           IMGLoader.getImage(
                              ((numError > 0) ? "error-hires.png" : "warning-hires.png")
                            ));
       mainImageIcon = new ImageIcon(mainImageIcon.getImage().getScaledInstance(130, 100, java.awt.Image.SCALE_SMOOTH));

--- a/src/main/java/org/edumips64/ui/swing/GUICode.java
+++ b/src/main/java/org/edumips64/ui/swing/GUICode.java
@@ -201,6 +201,9 @@ public class GUICode extends GUIComponent {
             if (instruction.getComment() != null) {
               return ";" + instruction.getComment();
             }
+            break;
+          default:
+            break;
         }
         return "";
       }

--- a/src/main/java/org/edumips64/ui/swing/GUIConfig.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIConfig.java
@@ -387,7 +387,7 @@ public class GUIConfig extends JDialog {
     }
 
     grid_add(panel, comp, gbl, gbc, .2, 0, 1, row, 1, 1);
-    panel.setMinimumSize(new java.awt.Dimension(10, 10));
+    panel.setMinimumSize(new Dimension(10, 10));
   }
 
   private static void grid_add(

--- a/src/main/java/org/edumips64/ui/swing/GUIData.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIData.java
@@ -216,6 +216,8 @@ public class GUIData extends GUIComponent {
           case 4:
             toReturn = memory.getCellByIndex(row).getComment();
             break;
+          default:
+            break;
           }
         } catch (IrregularStringOfBitsException | MemoryElementNotFoundException ex) {
           LOGGER.warning(ex.toString());

--- a/src/main/java/org/edumips64/ui/swing/GUIStatistics.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIStatistics.java
@@ -225,6 +225,8 @@ public class GUIStatistics extends GUIComponent {
       case 22:
         label.setText(" " + L1D_writes_misses + " " + CurrentLocale.getString("L1D WRITE MISSES"));
         return label;
+      default:
+        break;
       }
 
       return label;

--- a/src/main/java/org/edumips64/utils/io/LocalWriterAdapter.java
+++ b/src/main/java/org/edumips64/utils/io/LocalWriterAdapter.java
@@ -2,7 +2,7 @@
 
 package org.edumips64.utils.io;
 
-public class LocalWriterAdapter implements org.edumips64.utils.io.Writer {
+public class LocalWriterAdapter implements Writer {
   private java.io.Writer writer;
 
   public LocalWriterAdapter(java.io.Writer writer) {

--- a/src/webapp/css/main.css
+++ b/src/webapp/css/main.css
@@ -27,6 +27,7 @@
   .help-title {
     padding: 16px;
   }
+
   .help-content {
     padding: 12px;
   }
@@ -47,6 +48,7 @@
   100% {
     opacity: 1;
   }
+
   50% {
     opacity: 0.5;
   }

--- a/src/webapp/static/style.css
+++ b/src/webapp/static/style.css
@@ -209,6 +209,7 @@ html[data-theme="dark"] #memory th {
 div.error-accordion {
   position: sticky;
   top: 0;
+
   /* Keep the sticky Issues accordion above sibling accordions in the
      right panel, but well below MUI overlays such as the Help dialog
      (default modal z-index = 1300) and tooltips/popovers. The previous

--- a/utils/find-instructions.sh
+++ b/utils/find-instructions.sh
@@ -23,10 +23,10 @@ UNTESTED_FILENAME="/tmp/untested-instructions-$(date +%F-%T).txt"
 #     the DDIV tests.
 EXCLUDE_REGEX="^(BUBBLE|DDIV3)$"
 
-find "${TESTDIR}" -name "*.s" | xargs cat | sed "s/;.*$//" | sed "s/\s/ /g" | sed "s/^\s*//g" | sed "s/^.*://g" | cut -d " " -f 1 | grep -v "^[.;#/\\]" | tr "a-z" "A-Z" | grep -v "^$" | sort -u > "${TESTED_FILENAME}"
+find "${TESTDIR}" -name "*.s" -print0 | xargs -0 cat | sed "s/;.*$//" | sed "s/\s/ /g" | sed "s/^\s*//g" | sed "s/^.*://g" | cut -d " " -f 1 | grep -v "^[.;#/\\]" | tr "[:lower:]" "[:upper:]" | grep -v "^$" | sort -u > "${TESTED_FILENAME}"
 echo "Tested instructions: $(wc -l < "${TESTED_FILENAME}")"
 
-grep -ri class.*extends src/main/java/org/edumips64/core/is/ | grep -v Exception | grep -v abstract | sed "s/^.*class//" | cut -d" " -f 2 | sed "s/_/./g" | grep -vE "${EXCLUDE_REGEX}" | sort -u > "${IS_FILENAME}"
+grep -ri "class.*extends" src/main/java/org/edumips64/core/is/ | grep -v Exception | grep -v abstract | sed "s/^.*class//" | cut -d" " -f 2 | sed "s/_/./g" | grep -vE "${EXCLUDE_REGEX}" | sort -u > "${IS_FILENAME}"
 echo "Total instructions in the instruction set (excluding non-user-addressable ones): $(wc -l < "${IS_FILENAME}")"
 
 diff -u "${IS_FILENAME}" "${TESTED_FILENAME}" | grep "^-" | grep -v -- "^---" | grep -v -- "- " | sed "s/^-//" > "${UNTESTED_FILENAME}"

--- a/utils/jacoco-summary.py
+++ b/utils/jacoco-summary.py
@@ -8,7 +8,7 @@ Markdown summary. It performs no network access and executes no project code, so
 it is safe to run on untrusted pull request builds.
 """
 import sys
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # nosec B405 -- parses only the locally generated JaCoCo report
 
 COUNTERS = ["INSTRUCTION", "BRANCH", "LINE", "METHOD", "CLASS"]
 
@@ -19,7 +19,7 @@ def main():
         return 1
 
     report_path, out_path = sys.argv[1], sys.argv[2]
-    root = ET.parse(report_path).getroot()
+    root = ET.parse(report_path).getroot()  # nosec B314 -- trusted local file
 
     totals = {}
     for counter in root.findall("counter"):

--- a/utils/list-mentioned-issues-since-last-release.sh
+++ b/utils/list-mentioned-issues-since-last-release.sh
@@ -5,7 +5,7 @@ set -e
 LAST_TAG=$(git describe --abbrev=0 --tags)
 echo "All issues since ${LAST_TAG}"
 
-ISSUES=$(git log HEAD...${LAST_TAG} | egrep "#[0-9]{1,3}" -o | sed -e "s/#//" | sort -n | uniq)
+ISSUES=$(git log "HEAD...${LAST_TAG}" | grep -E "#[0-9]{1,3}" -o | sed -e "s/#//" | sort -n | uniq)
 for issue in $ISSUES; do
-  curl https://api.github.com/repos/EduMIPS64/edumips64/issues/${issue} 2>/dev/null | jq '[.number, .title, .state] | map(tostring) | join(" - ")' | sed 's/"//g'
+  curl "https://api.github.com/repos/EduMIPS64/edumips64/issues/${issue}" 2>/dev/null | jq '[.number, .title, .state] | map(tostring) | join(" - ")' | sed 's/"//g'
 done


### PR DESCRIPTION
## Summary

Addresses the ~1,700 open issues on the [Codacy dashboard](https://app.codacy.com/gh/EduMIPS64/edumips64/issues/current). The large majority were Codacy's default tool configurations contradicting deliberate project conventions; the rest were real (small) issues now fixed in code.

### Tool alignment — config files Codacy reads from the repo

| File | Effect |
|---|---|
| `.eslintrc.json` | Empty ESLint config. Kills ~930 issues from Codacy's deprecated ESLint demanding double quotes etc. — Biome (`biome.json`, single quotes) is this repo's JS linter, enforced in CI. |
| `ruleset.xml` | Curated PMD ruleset. Excludes naming rules that flag intentional domain naming (pipeline-stage methods `IF/ID/EX/MEM/WB`, instruction classes like `ADD_D`, snake_case test names — ~475 issues) and rules with confirmed false positives (picocli reflection, Swing inner classes). Keeps actionable correctness rules. |
| `.stylelintrc.json` | Minimal CSS rules matching what's worth enforcing. |
| `.prospector.yaml` | Disables docstring warnings for the small internal Python tools (23 issues). |

The ~120 markdownlint issues are already handled by #1964/#1965 (`.markdownlint.json` is also read by Codacy) and should clear on re-analysis.

### Real fixes in code

- **Java (PMD)**: `default` branches for 8 switch statements; removed 3 `new String()`; `equalsIgnoreCase` in Parser; simplified boolean expr in OR; removed 2 empty constructors; 6 unnecessary FQNs replaced with imports; `NOPMD` with rationale on intentional `new BigDecimal(double)` in FPU code (exact binary value of the double is the point — `valueOf` would round).
- **Shell (shellcheck)**: quoted variables (snap wrapper now also uses `"$@"` instead of `$*`), shebangs for the electron scripts, `egrep`→`grep -E`, useless `cat` removed, `find -print0 | xargs -0` in `utils/find-instructions.sh`.
- **Python**: inline pylint/bandit suppressions with rationale (Sphinx requires the `copyright` name; jacoco-summary parses a trusted local file).
- **CSS (stylelint)**: blank lines before nested rules/comments.
- **Kotlin (detekt)**: file-level `@Suppress` in `build.gradle.kts` for rules that don't add signal in a build script.

### Prevention

- The `lint-docs` CI job now also runs **shellcheck** on all tracked shell scripts (excluding `.squad/`), so shell regressions fail PRs directly.
- JS and Markdown were already CI-gated (Biome, markdownlint); Java/Python/CSS/Kotlin regressions are caught by Codacy's PR check, now configured by the committed files above instead of its defaults.
- New **Linting and static analysis** section in the developer guide documents the setup and the convention: when Codacy contradicts a deliberate convention, fix the config (with a comment), not the code.

## Verification

- `./gradlew test` passes (full desktop suite).
- `npm run lint` (Biome), `npm run lint:md`, and `shellcheck` on all tracked scripts: clean.
- `utils/find-instructions.sh` output verified byte-identical before/after the shell hardening.
- `ruleset.xml` XML-validated; `ci.yml` YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)