### PR TITLE
chore: fix last Codacy issues (W605, N817, zh conf.py suppression)

### DIFF
--- a/docs/user/common_conf.py
+++ b/docs/user/common_conf.py
@@ -97,7 +97,7 @@ html_context = {
     'html5_doctype': False,
     'use_meta_charset': False,
 }
-latex_preamble = u'''
+latex_preamble = r'''
 \DeclareUnicodeCharacter{22C3}{$\cup$}
 \DeclareUnicodeCharacter{2208}{$\in$}
 \DeclareUnicodeCharacter{221E}{$\infty$}

--- a/docs/user/zh/src/conf.py
+++ b/docs/user/zh/src/conf.py
@@ -25,7 +25,7 @@ pdf_font_path = [os.path.abspath(os.path.dirname(__file__))]
 pdf_language = "zh_CN"
 source_encoding = "utf-8"
 language = "zh_CN"
-copyright = u'2011, Andrea Spadaccini (and the EduMIPS64 development team)'
+copyright = u'2011, Andrea Spadaccini (and the EduMIPS64 development team)'  # pylint: disable=redefined-builtin -- name required by Sphinx
 man_pages = [
     ('index', 'edumips64', u'EduMIPS64 Documentation',
      [u'Andrea Spadaccini (and the EduMIPS64 development team)'], 1)

--- a/utils/jacoco-summary.py
+++ b/utils/jacoco-summary.py
@@ -8,7 +8,7 @@ Markdown summary. It performs no network access and executes no project code, so
 it is safe to run on untrusted pull request builds.
 """
 import sys
-import xml.etree.ElementTree as ET  # nosec B405 -- parses only the locally generated JaCoCo report
+import xml.etree.ElementTree as etree  # nosec B405 -- parses only the locally generated JaCoCo report
 
 COUNTERS = ["INSTRUCTION", "BRANCH", "LINE", "METHOD", "CLASS"]
 
@@ -19,7 +19,7 @@ def main():
         return 1
 
     report_path, out_path = sys.argv[1], sys.argv[2]
-    root = ET.parse(report_path).getroot()  # nosec B314 -- trusted local file
+    root = etree.parse(report_path).getroot()  # nosec B314 -- trusted local file
 
     totals = {}
     for counter in root.findall("counter"):


### PR DESCRIPTION
Fixes the last code-level issues on the Codacy dashboard (part of #222):

- **W605 ×3**: `latex_preamble` in `docs/user/common_conf.py` is now a raw string — the `\DeclareUnicodeCharacter` LaTeX commands were invalid Python escape sequences. The string content is byte-identical (invalid escapes were already kept literally).
- **N817**: `utils/jacoco-summary.py` imports `xml.etree.ElementTree as etree` (smoke-tested: output unchanged).
- `docs/user/zh/src/conf.py` gets the same `pylint: disable=redefined-builtin` suppression as the en/it configs (`copyright` is Sphinx's required variable name).

The one remaining dashboard item, `cmd_migrate is too complex (MC0001)` in the deploy script, is being ignored on Codacy with a rationale: it's the one-shot legacy-layout migration command, already executed in production and kept for reference — refactoring it has no payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)