### PR TITLE
docs: fix broken README screenshots, make them theme-aware

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD033": { "allowed_elements": ["picture", "source", "img"] },
   "MD024": { "siblings_only": true },
   "MD060": false
 }

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,15 @@ EduMIPS64 is a free cross-platform visual MIPS64 CPU simulator written in Java.
 
 It runs both as a stand-alone Java Swing application and as a React-based web Single-Page Application (deployed at <https://web.edumips.org>).
 
-![Swing UI Screenshot](http://www.edumips.org/edumips64-1.3.0.png)
-![Web UI Screenshot](http://www.edumips.org/screenshot-web.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://www.edumips.org/screenshot-web-dark.png">
+  <img alt="Web UI Screenshot" src="https://www.edumips.org/screenshot-web.png">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://www.edumips.org/screenshot-swing-dark.png">
+  <img alt="Swing UI Screenshot" src="https://www.edumips.org/screenshot-swing-light.png">
+</picture>
 
 ⚡ The web UI is also bundled as an Electron package for all major platforms.
 


### PR DESCRIPTION
The README's Swing screenshot hotlinked `www.edumips.org/edumips64-1.3.0.png`, which was deleted by the website redesign (EduMIPS64/www.edumips.org#2), so the README currently shows a broken image.

This points both screenshots at the website's current image set and wraps them in `<picture>` elements so GitHub serves the dark variants to dark-mode users:

- Web UI: `screenshot-web.png` / `screenshot-web-dark.png`
- Swing UI: `screenshot-swing-light.png` / `screenshot-swing-dark.png`

The web UI images themselves are being refreshed to the latest UI in EduMIPS64/www.edumips.org#4 (this PR works either way, since the file names are unchanged). `picture`/`source`/`img` are allowlisted for markdownlint's MD033; `npm run lint:md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)