### PR TITLE
fix(web): repaint the UI once per cycle when an execution delay is set

### DIFF
--- a/src/test/webapp/paced-execution.spec.js
+++ b/src/test/webapp/paced-execution.spec.js
@@ -1,0 +1,84 @@
+const { test, expect } = require('./fixtures');
+const { targetUri, waitForPageReady, loadProgram } = require('./test-utils');
+
+// Regression test for the paced-execution bug reported by Davide Patti:
+// with a non-zero execution delay, the UI showed a single update per
+// 50-cycle internal batch instead of one update per cycle, so the pipeline
+// colors in the editor never appeared to change.  The fix shrinks the
+// worker batch size to 1 whenever the execution delay is non-zero, matching
+// the Swing UI (CPUSwingWorker), which steps and repaints one cycle at a
+// time in verbose mode.
+
+// Long enough that a multi-step run crosses several cycles, short enough to
+// keep the test fast.
+const PROGRAM = `.code
+daddi r10, r0, 30
+loop:
+daddi r10, r10, -1
+bne r10, r0, loop
+syscall 0
+`;
+
+// Poll #stat-cycles and collect the distinct values observed while the
+// simulator executes.  With per-cycle batches each cycle produces its own
+// UI update; with the old batched behavior only the final value would be
+// visible.
+async function collectCycleReadings(page, durationMs, everyMs) {
+  const readings = new Set();
+  const t0 = Date.now();
+  while (Date.now() - t0 < durationMs) {
+    const text = await page.locator('#stat-cycles').textContent();
+    if (text && /^\d+$/.test(text)) {
+      readings.add(text);
+    }
+    await page.waitForTimeout(everyMs);
+  }
+  return readings;
+}
+
+test('multi-step with execution delay updates the UI once per cycle', async ({
+  page,
+}) => {
+  // Seed settings before the app boots: multi-step size 4, 300 ms delay.
+  await page.addInitScript(() => {
+    localStorage.setItem('edumips64:v1:stepStride', '4');
+    localStorage.setItem('edumips64:v1:executionDelayMs', '300');
+  });
+
+  await page.goto(targetUri);
+  await waitForPageReady(page);
+  await loadProgram(page, PROGRAM);
+
+  await page.click('#multi-step-button');
+
+  // 4 steps paced at 300 ms each finish in ~0.9 s (no delay before the first
+  // batch); sample well past that.  Each paced cycle is visible for ~300 ms,
+  // so 50 ms polling cannot miss it.  Expect at least 3 distinct readings;
+  // the old batched behavior showed exactly 1 (the final state).
+  const readings = await collectCycleReadings(page, 2000, 50);
+  expect(readings.size).toBeGreaterThanOrEqual(3);
+});
+
+test('run-all with execution delay updates the UI once per cycle', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('edumips64:v1:executionDelayMs', '100');
+  });
+
+  await page.goto(targetUri);
+  await waitForPageReady(page);
+  await loadProgram(page, PROGRAM);
+
+  await page.click('#run-button');
+
+  // With per-cycle pacing at 100 ms we observe many consecutive cycle
+  // values; the old behavior jumped 50 cycles per update, so within 2 s at
+  // most a couple of distinct values were visible.  Require a healthy
+  // margin above that.
+  const readings = await collectCycleReadings(page, 2000, 30);
+  expect(readings.size).toBeGreaterThanOrEqual(5);
+
+  // Stop the paced run so the page teardown doesn't race a long execution.
+  await page.click('#pause-button');
+});

--- a/src/webapp/executionReducer.ts
+++ b/src/webapp/executionReducer.ts
@@ -54,13 +54,14 @@ export interface ExecState {
  *
  * STEP_REQUESTED      — user pressed Step (or a multi-step batch was scheduled).
  *   payload: { stepsRemaining }  number of steps still queued after the
- *   current batch is sent to the worker (i.e. n - stride, where stride =
- *   Math.min(n, INTERNAL_STEPS_STRIDE)).  The actual worker.step(stride)
- *   call is a side-effect kept in the component.
+ *   current batch is sent to the worker (i.e. n - stride, where stride is
+ *   1 when a non-zero execution delay is set, INTERNAL_STEPS_STRIDE
+ *   otherwise).  The actual worker.step(stride) call is a side-effect kept
+ *   in the component.
  *
  * RUN_ALL_REQUESTED   — user pressed Run All.
  *   No payload.  Equivalent to the original setRunAll(true) + stepCode(...).
- *   The component calls worker.step(INTERNAL_STEPS_STRIDE) as a side-effect.
+ *   The component calls worker.step() with the current stride as a side-effect.
  *
  * RESULT_RECEIVED     — a step result arrived from the worker.
  *   payload: { status, encounteredBreak }

--- a/src/webapp/hooks/useExecutionController.ts
+++ b/src/webapp/hooks/useExecutionController.ts
@@ -10,6 +10,14 @@ import type { SimulatorResult, SimulatorWorker } from '../simulator/protocol';
 // The number of steps dispatched to the worker in each internal batch.
 // Kept here (not in Simulator.js) so the scheduling logic in updateState
 // can reference it without prop-drilling.
+//
+// This stride only applies when there is no execution delay: it exists purely
+// for throughput (fewer worker round-trips), and with no delay the
+// intermediate states would be invisible anyway.  When the user sets a
+// non-zero execution delay they want to *watch* the run, so batches shrink to
+// a single cycle and every cycle gets its own UI update — matching the Swing
+// UI, where CPUSwingWorker steps one cycle at a time and repaints (and
+// sleeps) between cycles in verbose mode.
 const INTERNAL_STEPS_STRIDE = 50;
 
 // ---------------------------------------------------------------------------
@@ -134,18 +142,26 @@ export function useExecutionController({
   // Public operations
   // ---------------------------------------------------------------------------
 
+  // Batch size for the next worker.step() call.  Read from the ref (not the
+  // prop) so a delay change mid-run takes effect from the next batch onward,
+  // switching between paced single-cycle updates and full-speed strides live.
+  const currentStride = useCallback(
+    () => (executionDelayRef.current > 0 ? 1 : INTERNAL_STEPS_STRIDE),
+    [],
+  );
+
   const runCode = useCallback(() => {
     dispatch({ type: 'RUN_ALL_REQUESTED' });
-    worker.step(INTERNAL_STEPS_STRIDE);
-  }, [worker]);
+    worker.step(currentStride());
+  }, [worker, currentStride]);
 
   const stepCode = useCallback(
     (n: number) => {
-      const toRun = Math.min(n, INTERNAL_STEPS_STRIDE);
+      const toRun = Math.min(n, currentStride());
       dispatch({ type: 'STEP_REQUESTED', stepsRemaining: n - toRun });
       worker.step(toRun);
     },
-    [worker],
+    [worker, currentStride],
   );
 
   const stopCode = useCallback(() => {
@@ -236,7 +252,7 @@ export function useExecutionController({
     } else if (stepsToRun > 0) {
       scheduleNextBatch(() => stepCode(stepsToRun));
     } else if (runAll) {
-      scheduleNextBatch(() => stepCode(INTERNAL_STEPS_STRIDE));
+      scheduleNextBatch(() => stepCode(currentStride()));
     }
     // else: single step finished normally; reducer set executing=false — done.
   };


### PR DESCRIPTION
## Summary

Credit to @davidepatti for finding this bug — thanks Davide! He noticed that with a 1-second execution delay, instructions clearly execute on a timer but the pipeline colors in the editor never appear to change.

### Root cause

With a non-zero execution delay, the web UI still executed internal batches of 50 cycles (`INTERNAL_STEPS_STRIDE`) atomically inside the worker, which posts a **single** result message per batch. The delay was inserted *between* those 50-cycle batches, so the UI repainted once per 50 cycles per delay period. On a loop, the pipeline lands in a similar phase every 50 cycles, so the editor highlighting looked frozen. The multi-step size had no visible effect on pacing either: any multi-step ≤ 50 cycles ran as one instant batch with a single repaint.

### Fix

Shrink the worker batch size to 1 whenever the execution delay is non-zero, so every cycle gets its own result message, UI repaint, and delay. This matches the Swing UI: `CPUSwingWorker` steps one cycle at a time and repaints (and sleeps) between cycles in verbose mode. With delay = 0 the 50-cycle stride is kept for throughput — the intermediate states are invisible anyway.

The stride is read from the delay ref at each batch boundary, so changing the delay mid-run switches between paced and full-speed execution live.

## Test plan

- New Playwright regression tests (`paced-execution.spec.js`) covering both Multi Step and Run All with a non-zero delay, asserting that multiple intermediate cycle states are visible in the UI. Verified they **fail** without the fix and pass with it.
- Full Playwright suite: 114 passed; the only failures are pre-existing/flaky in my environment (help-dialog needs locally built docs; dashboard-reorder passes on retry both with and without the fix).
- Unit tests (217), `tsc --noEmit`, and `biome check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)